### PR TITLE
Add flattened SystemVerilog versions

### DIFF
--- a/flatten_sv.py
+++ b/flatten_sv.py
@@ -1,0 +1,75 @@
+import re
+from pathlib import Path
+
+SRC = Path('src')
+DST = Path('src-flattened')
+DST.mkdir(exist_ok=True)
+
+# Load package content
+arith_pkg_path = SRC / 'arith_utils.sv'
+arith_pkg_content = arith_pkg_path.read_text() if arith_pkg_path.exists() else ''
+
+# Gather module/package definitions
+module_defs = {}
+module_deps = {}
+for path in SRC.glob('*.sv'):
+    text = path.read_text()
+    # modules
+    for m in re.finditer(r'(?s)\bmodule\s+([A-Za-z_][A-Za-z0-9_]*)\b(.*?)endmodule', text):
+        name = m.group(1)
+        body = 'module ' + name + m.group(2) + 'endmodule'
+        module_defs[name] = body
+    # packages
+    for m in re.finditer(r'(?s)\bpackage\s+([A-Za-z_][A-Za-z0-9_]*)\b(.*?)endpackage', text):
+        name = m.group(1)
+        body = 'package ' + name + m.group(2) + 'endpackage'
+        module_defs[name] = body
+
+module_names = list(module_defs.keys())
+
+# Simple comment stripper
+_comment_re = re.compile(r'//.*?$|/\*.*?\*/', re.S | re.M)
+
+def strip_comments(s: str) -> str:
+    return re.sub(_comment_re, '', s)
+
+# Determine dependencies for each module
+def find_deps(body: str):
+    body_nc = strip_comments(body)
+    deps = set()
+    for name in module_names:
+        pattern = re.compile(r'\b' + re.escape(name) + r'\b\s*(?:#\s*\(|\()', re.S)
+        for m in pattern.finditer(body_nc):
+            before = body_nc[max(0, m.start()-20):m.start()]
+            if re.search(r'module\s+' + re.escape(name), before):
+                continue
+            deps.add(name)
+            break
+    return deps
+
+for name, body in module_defs.items():
+    module_deps[name] = find_deps(body)
+
+# Recursive gather
+def gather(name, seen):
+    content = []
+    for dep in module_deps.get(name, []):
+        if dep not in seen:
+            seen.add(dep)
+            content.extend(gather(dep, seen))
+            content.append(module_defs[dep])
+    return content
+
+for path in SRC.glob('*.sv'):
+    text = path.read_text()
+    mods = [m.group(1) for m in re.finditer(r'\bmodule\s+([A-Za-z_][A-Za-z0-9_]*)', text)]
+    seen = set(mods)
+    dep_contents = []
+    for mname in mods:
+        dep_contents.extend(gather(mname, seen))
+    out = []
+    if arith_pkg_content:
+        out.append(arith_pkg_content)
+    out.append(text)
+    out.extend(dep_contents)
+    (DST / path.name).write_text('\n\n'.join(out))

--- a/src-flattened/AbsVal.sv
+++ b/src-flattened/AbsVal.sv
@@ -1,0 +1,193 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Computes the absolute value using a parallel-prefix 2's complementer.
+// Z = |A|
+
+module AbsVal #(
+	parameter int width = 8,   // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // result
+);
+
+	logic           Neg;  // negation enable
+	logic [width:0] AI;  // A inverted
+	logic [width:0] PO;  // prefix propagate out
+
+	// negation enable is sign (MSB) of A
+	assign Neg = A[width-1];
+
+	// invert A for complement and attach carry-in
+	assign AI  = {(A ^ {width{Neg}}), Neg};
+
+	// calculate prefix output propagate signal
+	PrefixAnd #(width + 1, speed) prefix (
+		.PI (AI),
+		.PO (PO)
+	);
+
+	// calculate result bits
+	assign Z = AI[width:1] ^ PO[width-1:0];
+
+endmodule
+
+
+
+module behavioural_AbsVal #(
+	parameter int width = 8,   // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // result
+);
+	assign Z = (signed'(A) < 0) ? -A : A;
+endmodule
+
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/Add.sv
+++ b/src-flattened/Add.sv
@@ -1,0 +1,245 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary adder using ripple-carry or parallel-prefix carry-lookahead logic.
+// S = A+B
+
+module Add #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	// Function: Binary adder using parallel-prefix carry-lookahead logic.
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// Internal signals for unsigned operands
+	logic [width-1:0] Auns, Buns, Suns;
+
+	// default ripple-carry adder as slow implementation
+	if (speed == lau_pkg::SLOW) begin
+		// type conversion: std_logic_vector -> unsigned
+		assign Auns = A;
+		assign Buns = B;
+
+		// addition
+		assign Suns = Auns + Buns;
+
+		// type conversion: unsigned -> std_logic_vector
+		assign S = Suns;
+	end else begin
+		// parallel-prefix adders as medium and fast implementations
+
+		// calculate prefix input generate/propagate signals
+		assign GI = A & B;
+		assign PI = A | B;
+		// calculate adder propagate signals (PT = A xor B)
+		assign PT = ~GI & PI;
+
+		// calculate prefix output generate/propagate signals
+		PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+		) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GO),
+			.PO(PO)
+		);
+
+		// calculate sum bits
+		assign S = PT ^ {GO[width-2:0], 1'b0};
+	end
+endmodule
+
+
+
+module behavioural_Add #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+	assign S = A + B;
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/AddC.sv
+++ b/src-flattened/AddC.sv
@@ -1,0 +1,237 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary adder using parallel-prefix carry-lookahead logic with:
+//   - carry-in (CI)
+//   - carry-out (CO)
+// {CO,S} = A+B+CI
+
+module AddC #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operands
+	input  logic [width-1:0] B,
+	input  logic             CI,  // carry in
+	output logic [width-1:0] S,   // sum
+	output logic             CO   // carry out
+);
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = (A[0] & B[0]) | (A[0] & CI) | (B[0] & CI);
+	assign PI[0] = 1'b0;
+	// calculate adder propagate signal (0) (PT = A xor B)
+	assign PT[0] = A[0] ^ B[0];
+	// calculate prefix input generate/propagate signals (1 to width-1)
+	for (genvar i = 1; i < width; i++) begin : preprocess
+		assign GI[i] = A[i] & B[i];
+		assign PI[i] = A[i] | B[i];
+		// calculate adder propagate signal (1 to width-1) (PT = A xor B)
+		assign PT[i] = ~GI[i] & PI[i];
+	end
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(width, speed) prefix (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// calculate sum and carry-out bits
+	assign S  = PT ^ {GO[width-2:0], CI};
+	assign CO = GO[width-1];
+
+endmodule
+
+
+
+module behavioural_AddC #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operands
+	input  logic [width-1:0] B,
+	input  logic             CI,  // carry in
+	output logic [width-1:0] S,   // sum
+	output logic             CO   // carry out
+);
+	assign {CO,S} = A + B + CI;
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/AddCfast.sv
+++ b/src-flattened/AddCfast.sv
@@ -1,0 +1,264 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary adder using parallel-prefix carry-lookahead logic with:
+//   - fast carry-in (CI)
+//   - carry-out (CO)
+// {CO,S} = A+B+CI
+
+module AddCfast #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operands
+	input  logic [width-1:0] B,
+	input  logic             CI,  // carry in
+	output logic [width-1:0] S,   // sum
+	output logic             CO   // carry out
+);
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// calculate prefix input generate/propagate signals
+	assign GI = A & B;
+	assign PI = A | B;
+	// calculate adder propagate signals (PT = A xor B)
+	assign PT = ~GI & PI;
+
+	// calculate prefix output generate/propagate signals with fast carry-in
+	PrefixAndOrCfast #(width, speed) prefix (
+		.GI (GI),
+		.PI (PI),
+		.CI (CI),
+		.GO (GO),
+		.PO (PO)
+	);
+
+	// calculate sum and carry-out bits
+	assign S  = PT ^ {GO[width-2:0], CI};
+	assign CO = GO[width-1];
+
+endmodule
+
+
+
+module behavioural_AddCfast #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operands
+	input  logic [width-1:0] B,
+	input  logic             CI,  // carry in
+	output logic [width-1:0] S,   // sum
+	output logic             CO   // carry out
+);
+	assign {CO,S} = A + B + CI;
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module PrefixAndOrCfast #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,
+	input  logic [width-1:0] PI,  // gen./prop. in
+	input  logic             CI,  // carry in
+	output logic [width-1:0] GO,
+	output logic [width-1:0] PO  // gen./prop. out
+);
+
+	logic [width-1:0] CIT;  // carry in temp
+	logic [width-1:0] GT, PT;  // gen./prop. temp
+
+	// normal prefix calculation
+	PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+	) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GT),
+			.PO(PT)
+	);
+
+	// additional prefix calculation level for fast carry-in
+	always_comb begin
+		CIT = {width{CI}};
+		GO  = GT | (PT & CIT);
+	end
+
+endmodule

--- a/src-flattened/AddCsv.sv
+++ b/src-flattened/AddCsv.sv
@@ -1,0 +1,99 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Three-operand carry-save adder using full-adders.
+
+module AddCsv #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A1,  // operands
+	input  logic [width-1:0] A2,
+	input  logic [width-1:0] A3,
+	output logic [width-1:0] S,   // sum / carry vector
+	output logic [width-1:0] C
+);
+
+	logic [width-1:0] CT;  // unshifted output carries
+
+	// carry-save addition using full-adders
+	for (genvar i = 0; i < width; i++) begin : bits
+		FullAdder fa (
+		.A  (A1[i]),
+		.B  (A2[i]),
+		.CI (A3[i]),
+		.S  (S[i] ),
+		.CO (CT[i])
+		);
+	end
+
+	// rotate output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule
+
+
+module behavioural_AddCsv #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A1,  // operands
+	input  logic [width-1:0] A2,
+	input  logic [width-1:0] A3,
+	output logic [width-1:0] S,   // sum / carry vector
+	output logic [width-1:0] C
+);
+	assign S = A1 ^ A2 ^ A3; // carry-less sum
+	assign C = ((A1 & A2) | (A1 & A3) | (A2 & A3)) << 1;
+endmodule

--- a/src-flattened/AddMod2Nm1.sv
+++ b/src-flattened/AddMod2Nm1.sv
@@ -1,0 +1,267 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary adder modulo (2^n - 1) with double zero representation
+// (1's complement adder) using end-around carry parallel-prefix structure
+// S = A+B mod (2^n -1)
+
+module AddMod2Nm1 #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+	logic CI, CO;  // end-around carries
+
+	// calculate prefix input generate/propagate signals
+	assign GI = A & B;
+	assign PI = A | B;
+	// calculate adder propagate signals (PT = A xor B)
+	assign PT = ~GI & PI;
+
+	// calculate prefix output generate/propagate signals with end-around carries
+	PrefixAndOrCendaround #(width, speed) prefix (
+		.GI (GI),
+		.PI (PI),
+		.CI (CI),
+		.GO (GO),
+		.PO (PO),
+		.CO (CO)
+	);
+
+	// end-around carry for addition modulo (2^n - 1), double zero repres.
+	assign CI = CO;
+
+	// calculate sum bits
+	assign S  = PT ^ {GO[width-2:0], CI};
+
+endmodule
+
+
+
+module behavioural_AddMod2Nm1 #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+	localparam int unsigned mod = 2**width -1;
+	logic [width:0] total;
+	assign total = {1'b0, A} + {1'b0, B};
+	// double-zero so total==mod is non-wrapping
+	assign S = (total <= mod) ? total : (total - mod);
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module PrefixAndOrCendaround #(
+	parameter int unsigned width = 8,    // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,
+	input  logic [width-1:0] PI,  // gen./prop. in
+	input  logic             CI,  // carry in
+	output logic [width-1:0] GO,
+	output logic [width-1:0] PO,  // gen./prop. out
+	output logic             CO   // carry out
+);
+
+	logic [width-1:0] GT, PT;  // gen./prop. temp
+
+	// normal prefix calculation
+	PrefixAndOr #(
+		.width(width),
+		.speed(speed)
+	) prefix_inst (
+		.GI(GI),
+		.PI(PI),
+		.GO(GT),
+		.PO(PT)
+	);
+
+	// carry-out
+	assign CO = GT[width-1];
+	// additional prefix calculation level for fast carry-in
+	assign GO = GT | (PT & {{width - 1{CI}}});
+	assign PO = PT;
+
+endmodule

--- a/src-flattened/AddMod2Nm1s0.sv
+++ b/src-flattened/AddMod2Nm1s0.sv
@@ -1,0 +1,267 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary adder modulo (2^n - 1) with single zero representation
+// (1's complement adder) using end-around carry parallel-prefix structure
+// S = A+B mod (2^n -1)
+
+module AddMod2Nm1s0 #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+	logic CI, CO;  // end-around carries
+
+	// calculate prefix input generate/propagate signals
+	assign GI = A & B;
+	assign PI = A | B;
+	// calculate adder propagate signals (PT = A xor B)
+	assign PT = ~GI & PI;
+
+	// calculate prefix output generate/propagate signals with end-around carries
+	PrefixAndOrCendaround #(width, speed) prefix (
+		.GI (GI),
+		.PI (PI),
+		.CI (CI),
+		.GO (GO),
+		.PO (PO),
+		.CO (CO)
+	);
+
+	// end-around carry for addition modulo (2^n - 1), single zero repres.
+	assign CI = CO | PO[width-1];
+
+	// calculate sum bits
+	assign S  = PT ^ {GO[width-2:0], CI};
+
+endmodule
+
+
+
+module behavioural_AddMod2Nm1s0 #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+	localparam int unsigned mod = 2**width -1;
+	logic [width:0] total;
+	assign total = {1'b0, A} + {1'b0, B};
+	// single-zero so total==mod is wrapping
+	assign S = (total < mod) ? total : (total - mod);
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module PrefixAndOrCendaround #(
+	parameter int unsigned width = 8,    // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,
+	input  logic [width-1:0] PI,  // gen./prop. in
+	input  logic             CI,  // carry in
+	output logic [width-1:0] GO,
+	output logic [width-1:0] PO,  // gen./prop. out
+	output logic             CO   // carry out
+);
+
+	logic [width-1:0] GT, PT;  // gen./prop. temp
+
+	// normal prefix calculation
+	PrefixAndOr #(
+		.width(width),
+		.speed(speed)
+	) prefix_inst (
+		.GI(GI),
+		.PI(PI),
+		.GO(GT),
+		.PO(PT)
+	);
+
+	// carry-out
+	assign CO = GT[width-1];
+	// additional prefix calculation level for fast carry-in
+	assign GO = GT | (PT & {{width - 1{CI}}});
+	assign PO = PT;
+
+endmodule

--- a/src-flattened/AddMod2Np1.sv
+++ b/src-flattened/AddMod2Np1.sv
@@ -1,0 +1,269 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary adder modulo (2^n + 1) using end-around carry parallel-prefix
+// structure, diminished-one number representation
+// S = A+B mod (2^n +1)
+
+module AddMod2Np1 #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+	logic CI, CO;  // end-around carries
+
+	// calculate prefix input generate/propagate signals
+	assign GI = A & B;
+	assign PI = A | B;
+	// calculate adder propagate signals (P = A xor B)
+	assign PT = ~GI & PI;
+
+	// calculate prefix output generate/propagate signals with end-around carries
+	PrefixAndOrCendaround #(width, speed) prefix (
+		.GI (GI),
+		.PI (PI),
+		.CI (CI),
+		.GO (GO),
+		.PO (PO),
+		.CO (CO)
+	);
+
+	// end-around carry for addition modulo (2^n + 1)
+	assign CI = ~CO;
+
+	// calculate sum bits
+	assign S  = PT ^ {GO[width-2:0], CI};
+
+endmodule
+
+
+
+module behavioural_AddMod2Np1 #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+	localparam int unsigned mod = 2**width +1;
+	logic [width+1:0] Auns, Buns, Suns; // normal unsigned representation
+	assign Auns = {2'b00, A} + 1; // recover diminished-one
+	assign Buns = {2'b00, B} + 1; // recover diminished-one
+	assign Suns = (Auns + Buns) % mod;
+	// zero is unique, otherwise diminished one
+	assign S = (S == 0) ? '0 : (S[width-1:0] - 1);
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module PrefixAndOrCendaround #(
+	parameter int unsigned width = 8,    // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,
+	input  logic [width-1:0] PI,  // gen./prop. in
+	input  logic             CI,  // carry in
+	output logic [width-1:0] GO,
+	output logic [width-1:0] PO,  // gen./prop. out
+	output logic             CO   // carry out
+);
+
+	logic [width-1:0] GT, PT;  // gen./prop. temp
+
+	// normal prefix calculation
+	PrefixAndOr #(
+		.width(width),
+		.speed(speed)
+	) prefix_inst (
+		.GI(GI),
+		.PI(PI),
+		.GO(GT),
+		.PO(PT)
+	);
+
+	// carry-out
+	assign CO = GT[width-1];
+	// additional prefix calculation level for fast carry-in
+	assign GO = GT | (PT & {{width - 1{CI}}});
+	assign PO = PT;
+
+endmodule

--- a/src-flattened/AddMop.sv
+++ b/src-flattened/AddMop.sv
@@ -1,0 +1,401 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Multi-operand adder using carry-save adder /array/tree and
+// ripple-carry/parallel-prefix final adder.
+// S = A[0]+A[1]+A[2]...+A[depth-1]
+
+module AddMop #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S   // sum
+);
+
+	logic [width-1:0] ST, CT;  // interm. sum/carry bits
+
+	// carry-save addition
+	AddMopCsv #(
+		.width(width),
+		.depth(depth),
+		.speed(speed)
+	) csvAdd (
+		.A (A),
+		.S (ST),
+		.C (CT)
+	);
+
+	// final carry-propagate addition
+	Add #(
+		.width(width),
+		.speed(speed)
+	) finalAdd (
+		.A (ST),
+		.B (CT),
+		.S (S)
+	);
+
+endmodule
+
+
+
+module behavioural_AddMop #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S   // sum
+);
+	always_comb begin : reduction
+		S = '0;
+		for (int i = 0; i < depth; i++) begin
+			S += A[width*i +: width];
+		end
+	end
+endmodule
+
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module Add #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	// Function: Binary adder using parallel-prefix carry-lookahead logic.
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// Internal signals for unsigned operands
+	logic [width-1:0] Auns, Buns, Suns;
+
+	// default ripple-carry adder as slow implementation
+	if (speed == lau_pkg::SLOW) begin
+		// type conversion: std_logic_vector -> unsigned
+		assign Auns = A;
+		assign Buns = B;
+
+		// addition
+		assign Suns = Auns + Buns;
+
+		// type conversion: unsigned -> std_logic_vector
+		assign S = Suns;
+	end else begin
+		// parallel-prefix adders as medium and fast implementations
+
+		// calculate prefix input generate/propagate signals
+		assign GI = A & B;
+		assign PI = A | B;
+		// calculate adder propagate signals (PT = A xor B)
+		assign PT = ~GI & PI;
+
+		// calculate prefix output generate/propagate signals
+		PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+		) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GO),
+			.PO(PO)
+		);
+
+		// calculate sum bits
+		assign S = PT ^ {GO[width-2:0], 1'b0};
+	end
+endmodule
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule

--- a/src-flattened/AddMopCsv.sv
+++ b/src-flattened/AddMopCsv.sv
@@ -1,0 +1,177 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Carry-save adder using linear- or tree-structured (m,2)-compressors.
+// The exact bit-pattern of S and C change depending on the structure 
+// of the implemented tree because operands are commutative and can be added in
+// different parts of the tree, contributing either to S or C. 
+// The only guarantee is that S+C is the same.
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule
+
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule

--- a/src-flattened/AddMulPPGenSgn.sv
+++ b/src-flattened/AddMulPPGenSgn.sv
@@ -1,0 +1,114 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Partial-product generator for unsigned adder-multiplier (Braun) (i.e.
+// multiplier is sum of two input operands). Sign treated by sign extension
+// (no Baugh-Wooley multiplier).
+//
+// Partial products for 4x4-bit signed multiplication (using sign extension):
+//
+//  x(0)y(3) x(0)y(3) x(0)y(3) x(0)y(3) x(0)y(3) x(0)y(2) x(0)y(1) x(0)y(0)
+//  x(1)y(3) x(1)y(3) x(1)y(3) x(1)y(3) x(1)y(2) x(1)y(1) x(1)y(0)        0
+//  x(2)y(3) x(2)y(3) x(2)y(3) x(2)y(2) x(2)y(1) x(2)y(0)        0        0
+//  x(3)y(3) x(3)y(3) x(3)y(2) x(3)y(1) x(3)y(0)        0        0        0
+////////////////////////////////////////////////////////////////////////////////
+//      p(7)     p(6)     p(5)     p(4)     p(3)     p(2)     p(1)     p(0)
+////////////////////////////////////////////////////////////////////////////////
+
+module AddMulPPGenSgn #(
+	parameter int widthX  = 8, // word width of XS, XC
+	parameter int widthY  = 8, // word width of Y
+	localparam int widthP = widthX+widthY
+) (
+	input logic [widthX-1:0] XS,  // multipliers
+	input logic [widthX-1:0] XC,
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [(widthX+1)*(widthP)-1:0] PP  // partial products
+);
+
+	logic [widthX-1:0] M1, M2;  // recoded multiplier
+	logic [widthY+1:0] YT, YBT;  // expanded Y
+
+	// recode multiplier
+	assign M1 = XS ^ XC;
+	assign M2 = XS & XC;
+
+	// expand Y (used for term 2y)
+	assign YT  = { Y[widthY-1],  Y[widthY-1:0], 1'b0};
+	assign YBT = {~Y[widthY-1], ~Y[widthY-1:0], 1'b0};
+
+	logic [(widthX+1)*widthP-1:0] ppt;
+
+	// partial product generation
+	always_comb begin
+		ppt = 0;
+		for (int i = 0; i < widthX-1; i++) begin
+			for (int k = 0; k <= widthY; k++) begin
+				ppt[i*widthP+i+k] = (M1[i] & YT[k+1]) | (M2[i] & YT[k]);
+			end
+			for (int k = widthY+1; k <= (widthY+widthX-i-1); k++) begin
+				ppt[i*widthP+i+k] = (M1[i] | M2[i]) & YT[widthY];
+			end
+		end
+		for (int k = 0; k <= widthY; k++) begin
+			ppt[(widthX-1)*widthP+widthX-1+k] = (M1[widthX-1] & YBT[k+1]) | (M2[widthX-1] & YBT[k]);
+		end
+		ppt[widthX*widthP+widthX-1] = M1[widthX-1];
+		ppt[widthX*widthP+widthX  ] = M2[widthX-1];
+		PP = ppt;
+	end
+
+endmodule

--- a/src-flattened/AddMulPPGenUns.sv
+++ b/src-flattened/AddMulPPGenUns.sv
@@ -1,0 +1,94 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Partial-product generator for unsigned adder-multiplier (Braun) (i.e.
+// multiplier is sum of two input operands).
+
+module AddMulPPGenUns #(
+	parameter int widthX = 8,  // word width of XS, XC
+	parameter int widthY = 8,  // word width of Y
+	localparam int widthP = widthX+widthY
+) (
+	input logic [widthX-1:0] XS,  // multipliers
+	input logic [widthX-1:0] XC,
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX*(widthP)-1:0] PP  // partial products
+);
+
+	logic [widthX-1:0] M1, M2;  // recoded multiplier
+	logic [widthY+1:0] YT;  // expanded Y
+
+	// recode multiplier
+	assign M1 = XS ^ XC;
+	assign M2 = XS & XC;
+
+	// expand Y (used for term 2y)
+	assign YT = {1'b0, Y, 1'b0};
+
+	logic [widthX*widthP-1:0] ppt;
+
+	// partial product generation
+	always_comb begin
+		ppt = 0;
+		for (int i = 0; i < widthX; i++) begin
+			for (int k = 0; k <= widthY; k++) begin
+				ppt[i*widthP+i+k] = (M1[i] & YT[k+1]) | (M2[i] & YT[k]);
+			end
+		end
+		PP = ppt;
+	end
+
+endmodule

--- a/src-flattened/AddMulSgn.sv
+++ b/src-flattened/AddMulSgn.sv
@@ -1,0 +1,457 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Title       : Signed adder-multiplier
+// Project     : VHDL Library of Arithmetic Units
+////////////////////////////////////////////////////////////////////////////////
+// File        : AddMulSgn.sv
+// Author      : Reto Zimmermann  <zimmi@iis.ee.ethz.ch>
+// Company     : Integrated Systems Laboratory, ETH Zurich
+// Date        : 1997/11/19
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 1998 Integrated Systems Laboratory, ETH Zurich
+////////////////////////////////////////////////////////////////////////////////
+// Description :
+// Adder-multiplier for signed numbers (Brown). First adds two numbers, then
+// multiplies the result with the multiplicand. Can be used for multiplication
+// with an input operand in carry-save number format. Result is only valid if
+// sum does not overflow.
+// P = (XS+XC)*Y
+////////////////////////////////////////////////////////////////////////////////
+
+module AddMulSgn #(
+	parameter int widthX = 8,     // word width of XS, XC (<= widthY)
+	parameter int widthY = 8,     // word width of Y
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [widthX-1:0] XS,  // multipliers
+	input logic [widthX-1:0] XC,
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX+widthY-1:0] P  // product
+);
+
+	logic [(widthX+1)*(widthX+widthY)-1:0] PP;  // partial products
+	logic [widthX+widthY-1:0] ST, CT;  // intermediate sum/carry bits
+
+	// generation of partial products
+	AddMulPPGenSgn #(
+		.widthX(widthX),
+		.widthY(widthY)
+	) ppGen (
+		.XS(XS),
+		.XC(XC),
+		.Y (Y),
+		.PP(PP)
+	);
+
+	// carry-save addition of partial products
+	AddMopCsv #(
+		.width(widthX + widthY),
+		.depth(widthX + 1),
+		.speed(speed)
+	) csvAdd (
+		.A(PP),
+		.S(ST),
+		.C(CT)
+	);
+
+	// final carry-propagate addition
+	Add #(
+		.width(widthX + widthY),
+		.speed(speed)
+	) cpAdd (
+		.A(ST),
+		.B(CT),
+		.S(P)
+	);
+
+endmodule
+
+
+
+module behavioural_AddMulSgn #(
+	parameter int widthX = 8,     // word width of XS, XC (<= widthY)
+	parameter int widthY = 8,     // word width of Y
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic signed [widthX-1:0] XS,  // multipliers
+	input  logic signed [widthX-1:0] XC,
+	input  logic signed [widthY-1:0] Y,  // multiplicand
+	output logic signed [widthX+widthY-1:0] P  // product
+);
+	assign P = (XS + XC) * Y;
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module Add #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	// Function: Binary adder using parallel-prefix carry-lookahead logic.
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// Internal signals for unsigned operands
+	logic [width-1:0] Auns, Buns, Suns;
+
+	// default ripple-carry adder as slow implementation
+	if (speed == lau_pkg::SLOW) begin
+		// type conversion: std_logic_vector -> unsigned
+		assign Auns = A;
+		assign Buns = B;
+
+		// addition
+		assign Suns = Auns + Buns;
+
+		// type conversion: unsigned -> std_logic_vector
+		assign S = Suns;
+	end else begin
+		// parallel-prefix adders as medium and fast implementations
+
+		// calculate prefix input generate/propagate signals
+		assign GI = A & B;
+		assign PI = A | B;
+		// calculate adder propagate signals (PT = A xor B)
+		assign PT = ~GI & PI;
+
+		// calculate prefix output generate/propagate signals
+		PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+		) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GO),
+			.PO(PO)
+		);
+
+		// calculate sum bits
+		assign S = PT ^ {GO[width-2:0], 1'b0};
+	end
+endmodule
+
+module AddMulPPGenSgn #(
+	parameter int widthX  = 8, // word width of XS, XC
+	parameter int widthY  = 8, // word width of Y
+	localparam int widthP = widthX+widthY
+) (
+	input logic [widthX-1:0] XS,  // multipliers
+	input logic [widthX-1:0] XC,
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [(widthX+1)*(widthP)-1:0] PP  // partial products
+);
+
+	logic [widthX-1:0] M1, M2;  // recoded multiplier
+	logic [widthY+1:0] YT, YBT;  // expanded Y
+
+	// recode multiplier
+	assign M1 = XS ^ XC;
+	assign M2 = XS & XC;
+
+	// expand Y (used for term 2y)
+	assign YT  = { Y[widthY-1],  Y[widthY-1:0], 1'b0};
+	assign YBT = {~Y[widthY-1], ~Y[widthY-1:0], 1'b0};
+
+	logic [(widthX+1)*widthP-1:0] ppt;
+
+	// partial product generation
+	always_comb begin
+		ppt = 0;
+		for (int i = 0; i < widthX-1; i++) begin
+			for (int k = 0; k <= widthY; k++) begin
+				ppt[i*widthP+i+k] = (M1[i] & YT[k+1]) | (M2[i] & YT[k]);
+			end
+			for (int k = widthY+1; k <= (widthY+widthX-i-1); k++) begin
+				ppt[i*widthP+i+k] = (M1[i] | M2[i]) & YT[widthY];
+			end
+		end
+		for (int k = 0; k <= widthY; k++) begin
+			ppt[(widthX-1)*widthP+widthX-1+k] = (M1[widthX-1] & YBT[k+1]) | (M2[widthX-1] & YBT[k]);
+		end
+		ppt[widthX*widthP+widthX-1] = M1[widthX-1];
+		ppt[widthX*widthP+widthX  ] = M2[widthX-1];
+		PP = ppt;
+	end
+
+endmodule
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule

--- a/src-flattened/AddMulUns.sv
+++ b/src-flattened/AddMulUns.sv
@@ -1,0 +1,449 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Adder-multiplier for unsigned numbers (Brown). First adds two numbers, then
+// multiplies the result with the multiplicand. Can be used for multiplication
+// with an input operand in carry-save number format. Result is only valid if
+// sum does not overflow.
+// P = (XS+XC)*Y
+
+module AddMulUns #(
+	parameter int widthX = 8,     // word width of XS, XC (<= widthY)
+	parameter int widthY = 8,     // word width of Y
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [widthX-1:0] XS,  // multipliers
+	input logic [widthX-1:0] XC,
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX+widthY-1:0] P  // product
+);
+
+	logic [widthX*(widthX+widthY)-1:0] PP;  // partial products
+	logic [widthX+widthY-1:0] ST, CT;  // intermediate sum/carry bits
+
+	// generation of partial products
+	AddMulPPGenUns #(
+		.widthX(widthX),
+		.widthY(widthY)
+	) ppGen (
+		.XS(XS),
+		.XC(XC),
+		.Y (Y),
+		.PP(PP)
+	);
+
+	// carry-save addition of partial products
+	AddMopCsv #(
+		.width(widthX + widthY),
+		.depth(widthX),
+		.speed(speed)
+	) csvAdd (
+		.A(PP),
+		.S(ST),
+		.C(CT)
+	);
+
+	// final carry-propagate addition
+	Add #(
+		.width(widthX + widthY),
+		.speed(speed)
+	) cpAdd (
+		.A(ST),
+		.B(CT),
+		.S(P)
+	);
+
+endmodule
+
+
+
+module behavioural_AddMulUns #(
+	parameter int widthX = 8,     // word width of XS, XC (<= widthY)
+	parameter int widthY = 8,     // word width of Y
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [widthX-1:0] XS,  // multipliers
+	input logic [widthX-1:0] XC,
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX+widthY-1:0] P  // product
+);
+	assign P = (XS + XC) * Y;
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module Add #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	// Function: Binary adder using parallel-prefix carry-lookahead logic.
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// Internal signals for unsigned operands
+	logic [width-1:0] Auns, Buns, Suns;
+
+	// default ripple-carry adder as slow implementation
+	if (speed == lau_pkg::SLOW) begin
+		// type conversion: std_logic_vector -> unsigned
+		assign Auns = A;
+		assign Buns = B;
+
+		// addition
+		assign Suns = Auns + Buns;
+
+		// type conversion: unsigned -> std_logic_vector
+		assign S = Suns;
+	end else begin
+		// parallel-prefix adders as medium and fast implementations
+
+		// calculate prefix input generate/propagate signals
+		assign GI = A & B;
+		assign PI = A | B;
+		// calculate adder propagate signals (PT = A xor B)
+		assign PT = ~GI & PI;
+
+		// calculate prefix output generate/propagate signals
+		PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+		) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GO),
+			.PO(PO)
+		);
+
+		// calculate sum bits
+		assign S = PT ^ {GO[width-2:0], 1'b0};
+	end
+endmodule
+
+module AddMulPPGenUns #(
+	parameter int widthX = 8,  // word width of XS, XC
+	parameter int widthY = 8,  // word width of Y
+	localparam int widthP = widthX+widthY
+) (
+	input logic [widthX-1:0] XS,  // multipliers
+	input logic [widthX-1:0] XC,
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX*(widthP)-1:0] PP  // partial products
+);
+
+	logic [widthX-1:0] M1, M2;  // recoded multiplier
+	logic [widthY+1:0] YT;  // expanded Y
+
+	// recode multiplier
+	assign M1 = XS ^ XC;
+	assign M2 = XS & XC;
+
+	// expand Y (used for term 2y)
+	assign YT = {1'b0, Y, 1'b0};
+
+	logic [widthX*widthP-1:0] ppt;
+
+	// partial product generation
+	always_comb begin
+		ppt = 0;
+		for (int i = 0; i < widthX; i++) begin
+			for (int k = 0; k <= widthY; k++) begin
+				ppt[i*widthP+i+k] = (M1[i] & YT[k+1]) | (M2[i] & YT[k]);
+			end
+		end
+		PP = ppt;
+	end
+
+endmodule
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule

--- a/src-flattened/AddSub.sv
+++ b/src-flattened/AddSub.sv
@@ -1,0 +1,238 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary adder-subtractor using parallel-prefix carry-lookahead logic.
+// S = SUB ? A-B : A+B
+
+module AddSub #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operands
+	input  logic [width-1:0] B,
+	input  logic             SUB,  // subtraction enable
+	output logic [width-1:0] S     // sum
+);
+
+	logic [width-1:0] BI;  // B inverted
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// invert B for subtraction
+	assign BI = B ^ {width{SUB}};
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = (A[0] & BI[0]) | (A[0] & SUB) | (BI[0] & SUB);
+	assign PI[0] = 1'b0;
+	// calculate adder propagate signal (0) (PT = A xor B)
+	assign PT[0] = A[0] ^ BI[0];
+	// calculate prefix input generate/propagate signals (1 to width-1)
+
+	for (genvar i = 1; i < width; i++) begin : preproc
+		assign GI[i] = A[i] & BI[i];
+		assign PI[i] = A[i] | BI[i];
+		// calculate adder propagate signal (1 to width-1) (PT = A xor B)
+		assign PT[i] = ~GI[i] & PI[i];
+	end
+
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(width, speed) prefix (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// calculate sum bits
+	assign S = PT ^ {GO[width-2:0], SUB};
+
+endmodule
+
+
+
+module behavioural_AddSub #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operands
+	input  logic [width-1:0] B,
+	input  logic             SUB,  // subtraction enable
+	output logic [width-1:0] S     // sum
+);
+	assign S = SUB ? (A-B) : (A+B);
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/AddSubC.sv
+++ b/src-flattened/AddSubC.sv
@@ -1,0 +1,246 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary adder-subtractor using parallel-prefix carry-lookahead logic with:
+//   - carry-in (CI), added or subtracted
+//   - carry-out (CO)
+// {CO,S} = SUB ? A-B+CI : A+B+CI
+
+module AddSubC #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operands
+	input  logic [width-1:0] B,
+	input  logic             CI,   // carry in (added/subtracted)
+	input  logic             SUB,  // subtraction enable
+	output logic [width-1:0] S,    // sum
+	output logic             CO    // carry out
+);
+
+	logic [width-1:0] BI;  // B inverted
+	logic             CII;  // CI inverted
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// invert B and CI for subtraction
+	assign BI = B ^ {width{SUB}};
+	assign CII = CI ^ SUB;
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = (A[0] & BI[0]) | (A[0] & CII) | (BI[0] & CII);
+	assign PI[0] = 1'b0;
+	// calculate adder propagate signal (0) (PT = A xor B)
+	assign PT[0] = A[0] ^ BI[0];
+	// calculate prefix input generate/propagate signals (1 to width-1)
+	for (genvar i = 1; i < width; i++) begin : preproc
+		assign GI[i] = A[i] & BI[i];
+		assign PI[i] = A[i] | BI[i];
+		// calculate adder propagate signal (1 to width-1) (PT = A xor B)
+		assign PT[i] = ~GI[i] & PI[i];
+	end
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(width, speed) prefix (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// calculate sum and carry-out bits
+	assign S  = PT ^ {GO[width-2:0], CII};
+	assign CO = GO[width-1] ^ SUB;
+
+endmodule
+
+
+
+module behavioural_AddSubC #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operands
+	input  logic [width-1:0] B,
+	input  logic             CI,   // carry in (added/subtracted)
+	input  logic             SUB,  // subtraction enable
+	output logic [width-1:0] S,    // sum
+	output logic             CO    // carry out
+);
+	assign {CO,S} = SUB ? (A-B-CI) : (A+B+CI);
+endmodule
+
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/AddSubV.sv
+++ b/src-flattened/AddSubV.sv
@@ -1,0 +1,256 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary adder-subtractor using parallel-prefix carry-lookahead logic with:
+//   - carry-in (CI), added or subtracted
+//   - 2's complement overflow flag (V)
+// S = SUB ? A-B : A+B
+// V = (S>MAX) | (S<MIN)
+
+module AddSubV #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operands
+	input  logic [width-1:0] B,
+	input  logic             CI,   // carry in (added/subtracted)
+	input  logic             SUB,  // subtraction enable
+	output logic [width-1:0] S,    // sum
+	output logic             V     // overflow flag
+);
+
+	logic [width-1:0] BI;  // B inverted
+	logic             CII;  // CI inverted
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// invert B and CI for subtraction
+	assign BI = B ^ {width{SUB}};
+	assign CII = CI ^ SUB;
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = (A[0] & BI[0]) | (A[0] & CII) | (BI[0] & CII);
+	assign PI[0] = 1'b0;
+	// calculate adder propagate signal (0) (PT = A xor B)
+	assign PT[0] = A[0] ^ BI[0];
+	// calculate prefix input generate/propagate signals (1 to width-1)
+	for (genvar i = 1; i < width; i++) begin : preproc
+		assign GI[i] = A[i] & BI[i];
+		assign PI[i] = A[i] | BI[i];
+		// calculate adder propagate signal (1 to width-1) (PT = A xor B)
+		assign PT[i] = ~GI[i] & PI[i];
+	end
+
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(width, speed) prefix (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// calculate sum and overflow bits
+	assign S = PT ^ {GO[width-2:0], CII};
+	assign V = GO[width-1] ^ GO[width-2];
+
+endmodule
+
+
+
+module behavioural_AddSubV #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operands
+	input  logic [width-1:0] B,
+	input  logic             CI,   // carry in (added/subtracted)
+	input  logic             SUB,  // subtraction enable
+	output logic [width-1:0] S,    // sum
+	output logic             V     // overflow flag
+);
+	localparam MAX = 2**(width-1) -1;
+	localparam MIN = - 2**(width-1);
+	logic signed [width+1:0] Sext, Aext, Bext, CIext;
+	assign Aext = signed'(A);
+	assign Bext = signed'(B);
+	assign CIext = {{width-1{1'b0}},CI};
+
+	assign Sext = SUB ? (Aext - Bext -CIext) : (Aext + Bext +CIext);
+	assign S = Sext[width-1:0];
+	assign V = (Sext>MAX) | (Sext<MIN);
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/AddV.sv
+++ b/src-flattened/AddV.sv
@@ -1,0 +1,247 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary adder using parallel-prefix carry-lookahead logic with:
+//   - carry-in (CI)
+//   - 2's complement overflow flag (V)
+// S = A + B +CI
+// V = (S>MAX) | (S<MIN)
+
+module AddV #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operands
+	input  logic [width-1:0] B,
+	input  logic             CI,  // carry in
+	output logic [width-1:0] S,   // sum
+	output logic             V    // overflow flag
+);
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = (A[0] & B[0]) | (A[0] & CI) | (B[0] & CI);
+	assign PI[0] = 1'b0;
+	// calculate adder propagate signal (0) (PT = A xor B)
+	assign PT[0] = A[0] ^ B[0];
+	// calculate prefix input generate/propagate signals (1 to width-1)
+	for (genvar i = 1; i < width; i++) begin : preproc
+		assign GI[i] = A[i] & B[i];
+		assign PI[i] = A[i] | B[i];
+		// calculate adder propagate signal (1 to width-1) (PT = A xor B)
+		assign PT[i] = ~GI[i] & PI[i];
+	end
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(width, speed) prefix (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// calculate sum and overflow bits
+	assign S = PT ^ {GO[width-2:0], CI};
+	assign V = GO[width-1] ^ GO[width-2];
+
+endmodule
+
+
+
+module behavioural_AddV #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operands
+	input  logic [width-1:0] B,
+	input  logic             CI,  // carry in
+	output logic [width-1:0] S,   // sum
+	output logic             V    // overflow flag
+);
+	localparam MAX = 2**(width-1) -1;
+	localparam MIN = - 2**(width-1);
+	logic signed [width+1:0] Sext, Aext, Bext, CIext;
+	assign Aext = signed'(A);
+	assign Bext = signed'(B);
+	assign CIext = {{width-1{1'b0}},CI};
+
+	assign Sext = (Aext + Bext +CIext);
+	assign S = Sext[width-1:0];
+	assign V = (Sext>MAX) | (Sext<MIN);
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/AllOneDet.sv
+++ b/src-flattened/AllOneDet.sv
@@ -1,0 +1,104 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Detection of the all-ones vector.
+// Z = (A == {width{1'b1}})
+
+module AllOneDet #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic             Z   // all-ones flag
+);
+	// all-ones detection
+	RedAnd #(width) zeroFlag (
+		.A(A),
+		.Z(Z)
+	);
+
+endmodule
+
+
+
+module behavioural_AllOneDet #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic             Z   // all-ones flag
+);
+	assign Z = (A == {width{1'b1}});
+endmodule
+
+module RedAnd #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,  // input vector
+	output logic             Z   // output bit
+);
+
+	logic zv;
+
+	// AND all bits
+	// Using a procedural block for behavioral description
+	always_comb begin
+		zv = A[0];
+		for (int i = 1; i < width; i++) begin
+			zv &= A[i];
+		end
+		Z = zv;
+	end
+
+endmodule

--- a/src-flattened/AllZeroDet.sv
+++ b/src-flattened/AllZeroDet.sv
@@ -1,0 +1,110 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Detection of the all-zeroes vector.
+// Z = (A == '0)
+
+module AllZeroDet #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic             Z   // all-zeroes flag
+);
+
+	logic ZT;  // temp.
+
+	// all-zeroes detection
+	RedOr #(width) zeroFlag (
+		.A(A),
+		.Z(ZT)
+	);
+
+	// result
+	assign Z = ~ZT;
+
+endmodule
+
+
+
+module behavioural_AllZeroDet #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic             Z   // all-zeroes flag
+);
+	assign Z = (A == '0);
+endmodule
+
+module RedOr #(
+	parameter int width = 8  // word width
+) (
+	input logic [width-1:0] A,  // input vector
+	output logic Z  // output bit
+);
+
+	logic zv;
+	
+	// OR all bits
+	// behavioral description used (well handled by all synthesizers)
+	always_comb begin
+		zv = A[0];
+		for (int i = 1; i < width; i++) begin
+			zv |= A[i];
+		end
+		Z = zv;
+	end
+
+endmodule

--- a/src-flattened/Bin2Gray.sv
+++ b/src-flattened/Bin2Gray.sv
@@ -1,0 +1,89 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Converts a number from binary to Gray representation.
+
+module Bin2Gray #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] B,  // binary input
+	output logic [width-1:0] G   // Gray output
+);
+
+	logic [width:0] BT;  // temp.
+
+	// expand B
+	assign BT = {1'b0, B};
+
+	// convert binary to Gray
+	for (genvar i = 0; i < width; i++) begin : b2g
+		assign G[i] = BT[i+1] ^ BT[i];
+	end
+
+endmodule
+
+
+
+module behavioural_Bin2Gray #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] B,  // binary input
+	output logic [width-1:0] G   // Gray output
+);
+
+	assign G = B ^ (B >> 1);
+
+endmodule

--- a/src-flattened/CmpEQ.sv
+++ b/src-flattened/CmpEQ.sv
@@ -1,0 +1,90 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Equality comparison of two numbers.
+// EQ = (A == B)
+
+module CmpEQ #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic             EQ  // equal flag
+);
+
+	logic [width-1:0] EQT;  // temp.
+
+	// comparison of individual bits
+	for (genvar i = 0; i < width; i++) begin : cmpBit
+		assign EQT[i] = ~(A[i] ^ B[i]);
+	end
+
+	// AND all comparison bits
+	assign EQ = &EQT;
+
+endmodule
+
+
+
+module behavioural_CmpEQ #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic             EQ  // equal flag
+);
+	assign EQ = (A == B);
+endmodule

--- a/src-flattened/CmpEQGE.sv
+++ b/src-flattened/CmpEQGE.sv
@@ -1,0 +1,234 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Equality and magnitude (i.e. greater equal) comparison of two numbers by a
+// simplified subtraction.
+// EQ = (A == B)
+// GE = (A >= B)
+
+module CmpEQGE #(
+	parameter int width = 8,   // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operands
+	input  logic [width-1:0] B,
+	output logic             EQ,  // equal flag
+	output logic             GE   // greater equal flag
+);
+
+	logic [width-1:0] GI;  // prefix gen./prop. in
+	logic [width-1:0] PI;  // prefix gen./prop. in
+	logic [width-1:0] GO;  // prefix gen./prop. out
+	logic [width-1:0] PO;  // prefix gen./prop. out
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = A[0] | ~B[0];
+	assign PI[0] = ~(A[0] ^ B[0]);
+
+	// calculate prefix input generate/propagate signals (1 to width-1)
+	for (genvar i = 1; i < width; i++) begin : preproc
+		assign GI[i] = A[i] & ~B[i];
+		assign PI[i] = ~(A[i] ^ B[i]);
+	end
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(width, speed) prefix (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// result
+	assign EQ = PO[width-1];
+	assign GE = GO[width-1];
+
+endmodule
+
+
+
+module behavioural_CmpEQGE #(
+	parameter int width = 8,   // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operands
+	input  logic [width-1:0] B,
+	output logic             EQ,  // equal flag
+	output logic             GE   // greater equal flag
+);
+	assign EQ = (A == B);
+	assign GE = (A >= B);
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/CmpGE.sv
+++ b/src-flattened/CmpGE.sv
@@ -1,0 +1,230 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Magnitude (i.e. greater equal) comparison of two numbers by a simplified
+// subtraction.
+// GE = (A >= B)
+
+module CmpGE #(
+	parameter int width = 8,   // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic             GE  // greater equal flag
+);
+
+	logic [width-1:0] GI;  // prefix gen./prop. in
+	logic [width-1:0] PI;  // prefix gen./prop. in
+	logic [width-1:0] GO;  // prefix gen./prop. out
+	logic [width-1:0] PO;  // prefix gen./prop. out
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = A[0] | ~B[0];
+	assign PI[0] = ~(A[0] ^ B[0]);
+
+	// calculate prefix input generate/propagate signals (1 to width-1)
+	for (genvar i = 1; i < width; i++) begin : preproc
+		assign GI[i] = A[i] & ~B[i];
+		assign PI[i] = ~(A[i] ^ B[i]);
+	end
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(width, speed) prefix (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// result
+	assign GE = GO[width-1];
+
+endmodule
+
+
+
+module behavioural_CmpGE #(
+	parameter int width = 8,   // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic             GE  // greater equal flag
+);
+	assign GE = (A >= B);
+endmodule
+
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/Cnt.sv
+++ b/src-flattened/Cnt.sv
@@ -1,0 +1,176 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// (m,k)-counter adds m bits. Result is sum vector of k bits.
+// Composed of (m,k)-counter slices. Condition: depth > 1.
+// S = A[0]+A[1]+A[2]...+A[depth-1]
+
+module Cnt #(
+	parameter int              depth = 18,            // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [depth-1:0] A,  // input bits
+	output logic [lau_pkg::log2floor(depth):0] S  // sum output
+);
+
+	localparam m = depth;  // number of input bits
+	localparam n = lau_pkg::log2floor(depth) +1;  // number of output bits
+	logic [m*n:0] CT;  // intermediate carries
+
+	// input bits are first intermediate carries
+	assign CT[m-1:0] = A;
+
+	// linear arrangement of (m,k)-counter slices
+	for (genvar i = 0; i < n-2; i++) begin : bits
+		CntSlice #(m/(2**i), speed) slice (
+			.A (CT[i*m + m/(2**i) -1 : i*m]),
+			.S (S[i]),
+			.CO(CT[(i+1)*m + m/(2**(i+1)) -1 : (i+1)*m])
+		);
+	end
+
+	// add third carry if only two exist
+	if (m/ 2**(n-2) == 2) begin : even
+		assign CT[(n-2)*m+2] = 1'b0;
+	end
+
+	// full-adder for adding the last three carries
+	FullAdder fa0 (
+		.A (CT[(n-2)*m]),
+		.B (CT[(n-2)*m+1]),
+		.CI(CT[(n-2)*m+2]),
+		.S (S[n-2]),
+		.CO(S[n-1])
+	);
+
+endmodule
+
+
+
+module behavioural_Cnt #(
+	parameter int              depth = 18,            // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [depth-1:0] A,  // input bits
+	output logic [lau_pkg::log2floor(depth):0] S  // sum output
+);
+	always_comb begin
+		S = '0;
+		for(int i = 0; i < depth; i++) begin
+			S += A[i];
+		end
+	end
+endmodule
+
+module CntSlice #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [  depth-1:0] A,  // input bits
+	output logic               S,  // sum out
+	output logic [depth/2-1:0] CO  // carries out
+);
+
+	localparam noFA = depth / 2;  // number of used full-adders
+	localparam depthOdd = depth + ((depth + 1) % 2);  // next higher odd
+	logic [3*noFA:0] F;  // FIFO vector of int. signals
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+	// add a zero if even number of input bits
+	if (depth < depthOdd) begin
+		assign F[depthOdd-1] = 1'b0;
+	end
+
+	// counter with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCnt
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depthOdd]),
+			.CO(CO[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < noFA; i++) begin : linear
+			FullAdder fa (
+				.A (F[i*2+1]),
+				.B (F[i*2+2]),
+				.CI(F[depthOdd+i-1]),
+				.S (F[depthOdd+i]),
+				.CO(CO[i])
+			);
+		end
+	end  // counter with tree structure
+	else begin : fastCnt
+		// tree arrangement of full-adders
+		for (genvar i = 0; i < noFA; i++) begin : tree
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depthOdd+i]),
+				.CO(CO[i])
+			);
+		end
+	end
+
+	// sum out
+	assign S = F[3*noFA];
+
+endmodule

--- a/src-flattened/CntSlice.sv
+++ b/src-flattened/CntSlice.sv
@@ -1,0 +1,119 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Composed of full-adders arranged in linear or tree structure. Used as slice
+// for building (m,k)-counters. Forwards carries to next higher slice.
+// Condition: m > 3.
+
+module CntSlice #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [  depth-1:0] A,  // input bits
+	output logic               S,  // sum out
+	output logic [depth/2-1:0] CO  // carries out
+);
+
+	localparam noFA = depth / 2;  // number of used full-adders
+	localparam depthOdd = depth + ((depth + 1) % 2);  // next higher odd
+	logic [3*noFA:0] F;  // FIFO vector of int. signals
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+	// add a zero if even number of input bits
+	if (depth < depthOdd) begin
+		assign F[depthOdd-1] = 1'b0;
+	end
+
+	// counter with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCnt
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depthOdd]),
+			.CO(CO[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < noFA; i++) begin : linear
+			FullAdder fa (
+				.A (F[i*2+1]),
+				.B (F[i*2+2]),
+				.CI(F[depthOdd+i-1]),
+				.S (F[depthOdd+i]),
+				.CO(CO[i])
+			);
+		end
+	end  // counter with tree structure
+	else begin : fastCnt
+		// tree arrangement of full-adders
+		for (genvar i = 0; i < noFA; i++) begin : tree
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depthOdd+i]),
+				.CO(CO[i])
+			);
+		end
+	end
+
+	// sum out
+	assign S = F[3*noFA];
+
+endmodule

--- a/src-flattened/Cpr.sv
+++ b/src-flattened/Cpr.sv
@@ -1,0 +1,139 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// (m,2)-compressor adds m bits. Result is 2 bits, one sum bit S and one carry
+// bit C. m-2 intermediate carries are forwarded to next higher compressor
+// (note: many parallel compressors form a multi-operand carry-save adder).
+// Composed of full-adders arranged linearly or in tree structure.
+// Condition: m >= 4.
+// Linear structure: structure depth = # operands - 2
+// Tree structure:
+//   structure depth :   2   3   4   5   6   7   8   9  10  11  12
+//   # operands      :   4   6   9  13  19  28  42  63  94 141 211
+// 
+// The exact bit-pattern of CO changes depending on the structure 
+// of the implemented tree because operands are commutative and can be added in
+// different parts of the tree, contributing to different COs. 
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule

--- a/src-flattened/Dec.sv
+++ b/src-flattened/Dec.sv
@@ -1,0 +1,191 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Decrementer using parallel-prefix propagate-lookahead logic.
+// Z = A-1
+
+module Dec #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // result
+);
+
+	logic [width-1:0] AI;  // A inverted
+	logic [width-1:0] PO;  // prefix propagate out
+
+	// invert A for decrement
+	assign AI = ~A;
+
+	// calculate prefix output propagate signal
+	PrefixAnd #(
+		.width(width),
+		.speed(speed)
+	) prefix (
+		.PI(AI),
+		.PO(PO)
+	);
+
+	// calculate result bits
+	assign Z = A ^ {PO[width-2:0], 1'b1};
+
+endmodule
+
+
+
+module behavioural_Dec #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // result
+);
+	assign Z = A - 1;
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/DecC.sv
+++ b/src-flattened/DecC.sv
@@ -1,0 +1,198 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Decrementer using parallel-prefix propagate-lookahead logic with:
+//   - carry-in (CI)
+//   - carry-out (CO)
+// {CO,Z} = A-CI
+
+module DecC #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operand
+	input  logic             CI,  // carry in
+	output logic [width-1:0] Z,   // result
+	output logic             CO   // carry out
+);
+
+	logic [width:0] AI;  // A inverted
+	logic [width:0] PO;  // prefix propagate out
+
+	// invert A for decrement
+	assign AI = {~A, CI};
+
+	// calculate prefix output propagate signal
+	PrefixAnd #(
+		.width(width + 1),
+		.speed(speed)
+	) prefix (
+		.PI(AI),
+		.PO(PO)
+	);
+
+	// calculate result and carry-out bits
+	assign Z  = A ^ PO[width-1:0];
+	assign CO = PO[width];
+
+endmodule
+
+
+
+module behavioural_DecC #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operand
+	input  logic             CI,  // carry in
+	output logic [width-1:0] Z,   // result
+	output logic             CO   // carry out
+);
+	assign {CO,Z} = A - CI;
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/Decode.sv
+++ b/src-flattened/Decode.sv
@@ -1,0 +1,89 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Decodes a binary number into a vector with a '1' at the according position.
+// Z = 1'b1 << A
+// Examples: A = "101" -> Z = "00100000".
+
+module Decode #(
+	parameter int width = 8  // word width
+) (
+	input  logic [($clog2(width)-1):0] A,  // encoded input
+	output logic [          width-1:0] Z   // output vector
+);
+
+	integer Aint;  // integer
+
+	// type conversion: std_logic_vector -> integer
+	assign Aint = A;
+
+	// decoding
+	for (genvar i = 0; i < width; i++) begin : dec
+		assign Z[i] = (Aint == i) ? 1'b1 : 1'b0;
+	end
+
+endmodule
+
+
+
+module behavioural_Decode #(
+	parameter int width = 8  // word width
+) (
+	input  logic [($clog2(width)-1):0] A,  // encoded input
+	output logic [          width-1:0] Z   // output vector
+);
+	assign Z = 1 << A;
+endmodule

--- a/src-flattened/DivArrSgn.sv
+++ b/src-flattened/DivArrSgn.sv
@@ -1,0 +1,163 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Restoring array divider for signed numbers. The divisor must be normalized
+// (i.e. Y(widthY-1) = '1')
+// Q = floor(X/Y)
+// R = X mod Y
+// 
+// NOTE: not completed. very difficult to implement for signed numbers.
+// problem with zero result if result otherwise negative
+
+module DivArrSgn #(
+	parameter int widthX = 16,  // word width of X
+	parameter int widthY = 8    // word width of Y
+) (
+	input  logic [     widthX-1:0] X,  // dividend
+	input  logic [     widthY-1:0] Y,  // divisor, normalized
+	output logic [widthX-widthY:0] Q,  // quotient
+	output logic [     widthY-1:0] R   // remainder
+);
+
+	localparam int widthQ = widthX - widthY + 1;  // word width of Q
+
+	logic [                 widthY:0] YI;  // inverted Y
+	logic [    widthQ*(widthY+1)-1:0] ST;  // sums
+	logic [               widthQ-1:0] QT;  // sums
+	logic [(widthQ+1)*(widthY+2)-1:0] RT;  // remainders
+	logic [    widthQ*(widthY+2)-1:0] CT;  // carries
+
+	// invert divisor Y for subtraction
+	assign YI = {~Y[widthY-1], ~Y};
+
+	// first partial remainder is dividend X
+	assign RT[(widthQ*(widthY+2)+1)+:widthY] = {X[widthX-1], X[widthX-1:widthX-widthY+1]};
+
+	// process one row for each quotient bit
+	for (genvar k = widthQ - 1; k >= 0; k--) begin : row
+		// carry-in = '1' for subtraction
+		assign CT[k*(widthY+2)] = 1'b1;
+		// attach next dividend bit to current remainder
+		assign RT[((k+1)*(widthY+2))] = X[k];
+
+		// perform subtraction using ripple-carry adder
+		// (current partial remainder - divisor)
+		for (genvar i = widthY; i >= 0; i--) begin : bits
+			FullAdder #() fa (
+				.A (YI[i]),
+				.B (RT[((k+1)*(widthY+2))+i]),
+				.CI(CT[(k*(widthY+2))+i]),
+				.S (ST[(k*(widthY+1))+i]),
+				.CO(CT[(k*(widthY+2))+i+1])
+			);
+		end
+
+		always_comb begin
+			// if subtraction result is negative => quotient bit = '0'
+			QT[k] = CT[k*(widthY+2)+widthY+1];
+
+			// restore previous partial remainder is quotient bit = '0'
+			if (QT[k] == 1'b0) begin
+				RT[k*(widthY+2)+1+:widthY+1] = RT[((k+1)*(widthY+2))+:widthY+1];
+			end else begin
+				RT[k*(widthY+2)+1+:widthY+1] = ST[k*(widthY+1)+:widthY+1];
+			end
+		end
+	end
+
+	assign Q = QT;
+	// last partial remainder is division remainder
+	assign R = RT[widthY:1];
+
+endmodule
+
+
+
+module behavioural_DivArrSgn #(
+	parameter int widthX = 16,  // word width of X
+	parameter int widthY = 8    // word width of Y
+) (
+	input  logic [     widthX-1:0] X,  // dividend
+	input  logic [     widthY-1:0] Y,  // divisor, normalized
+	output logic [widthX-widthY:0] Q,  // quotient
+	output logic [     widthY-1:0] R   // remainder
+);
+	assign Q = signed'(X) / signed'(Y);
+	assign R = signed'(X) % signed'(Y);
+endmodule
+
+module FullAdder (
+	input  logic A,
+	input  logic B,
+	input  logic CI,  // operands
+	output logic S,
+	output logic CO  // sum and carry out
+);
+
+	logic [1:0] Auns, Buns, CIuns, Suns;  // unsigned temp
+
+	// type conversion: std_logic -> 2-bit unsigned
+	assign Auns  = {1'b0, A};
+	assign Buns  = {1'b0, B};
+	assign CIuns = {1'b0, CI};
+
+	// should force the compiler to use a full-adder cell
+	assign Suns = Auns + Buns + CIuns;
+
+	// type conversion: 2-bit unsigned -> std_logic
+	assign {CO, S} = Suns;
+
+endmodule

--- a/src-flattened/DivArrUns.sv
+++ b/src-flattened/DivArrUns.sv
@@ -1,0 +1,175 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Restoring array divider for unsigned numbers. Divisor must be normalized
+// (i.e. Y(widthY-1) = '1')
+// Q = floor(X/Y)
+// R = X mod Y
+
+module DivArrUns #(
+	parameter int widthX = 16,  // word width of X
+	parameter int widthY = 8    // word width of Y
+) (
+	input  logic [     widthX-1:0] X,  // dividend
+	input  logic [     widthY-1:0] Y,  // divisor, normalized
+	output logic [widthX-widthY:0] Q,  // quotient
+	output logic [     widthY-1:0] R   // remainder
+);
+
+	localparam int widthQ = widthX - widthY + 1;  // word width of Q
+
+	logic [                 widthY:0] YI;  // inverted Y
+	logic [    widthQ*(widthY+1)-1:0] ST;  // sums
+	logic [               widthQ-1:0] QT;  // sums
+	logic [(widthQ+1)*(widthY+2)-1:0] RT;  // remainders
+	logic [    widthQ*(widthY+2)-1:0] CT;  // carries
+
+	// invert divisor Y for subtraction
+	assign YI = {1'b1, ~Y};
+
+	// first partial remainder is dividend X
+	assign RT[(widthQ*(widthY+2)+1)+:widthY] = {1'b0, X[widthX-1:widthX-widthY+1]};
+
+	// process one row for each quotient bit
+
+	for (genvar k = widthQ - 1; k >= 0; k--) begin : row
+		// carry-in = '1' for subtraction
+		assign CT[k*(widthY+2)] = 1'b1;
+		// attach next dividend bit to current remainder
+		assign RT[((k+1)*(widthY+2))] = X[k];
+
+		// perform subtraction using ripple-carry adder
+		// (current partial remainder - divisor)
+		for (genvar i = widthY; i >= 0; i--) begin : bits
+			FullAdder #() fa (
+				.A (YI[i]),
+				.B (RT[((k+1)*(widthY+2))+i]),
+				.CI(CT[(k*(widthY+2))+i]),
+				.S (ST[(k*(widthY+1))+i]),
+				.CO(CT[(k*(widthY+2))+i+1])
+			);
+		end
+
+		always_comb begin
+			// if subtraction result is negative => quotient bit = '0'
+			QT[k] = CT[k*(widthY+2)+widthY+1];
+
+			// restore previous partial remainder if quotient bit = '0'
+			if (QT[k] == 1'b0) begin
+				RT[k*(widthY+2)+1+:widthY+1] = RT[((k+1)*(widthY+2))+:widthY];
+			end else begin
+				RT[k*(widthY+2)+1+:widthY+1] = ST[k*(widthY+1)+:widthY];
+			end
+		end
+	end
+
+	assign Q = QT;
+	// last partial remainder is division remainder
+	assign R = RT[widthY:1];
+
+endmodule
+
+
+
+// X is widthX-bits wide and we have to make sure 
+// the result is representable in widthY-bits
+module behavioural_DivArrUns #(
+	parameter int widthX = 16,  // word width of X
+	parameter int widthY = 8    // word width of Y
+) (
+	input  logic [     widthX-1:0] X,  // dividend
+	input  logic [     widthY-1:0] Y,  // divisor, normalized
+	output logic [widthX-widthY:0] Q,  // quotient
+	output logic [     widthY-1:0] R   // remainder
+);
+	localparam QMAX = 2**(widthY-1) -1;
+	logic [widthX:0] Qtmp;
+	always_comb begin
+		Qtmp = X / Y;
+		// Q < 2^n -> X<2^n *Y, where n is width of Y
+		// -> Y in [2^(n-1), 2^n -1], ie Y must be normalized
+		if(Qtmp > QMAX) begin
+			R = 'x;
+			Q = 'x;
+		end else begin
+			R = X % Y;
+			Q = X / Y;
+		end
+	end
+endmodule
+
+module FullAdder (
+	input  logic A,
+	input  logic B,
+	input  logic CI,  // operands
+	output logic S,
+	output logic CO  // sum and carry out
+);
+
+	logic [1:0] Auns, Buns, CIuns, Suns;  // unsigned temp
+
+	// type conversion: std_logic -> 2-bit unsigned
+	assign Auns  = {1'b0, A};
+	assign Buns  = {1'b0, B};
+	assign CIuns = {1'b0, CI};
+
+	// should force the compiler to use a full-adder cell
+	assign Suns = Auns + Buns + CIuns;
+
+	// type conversion: 2-bit unsigned -> std_logic
+	assign {CO, S} = Suns;
+
+endmodule

--- a/src-flattened/Encode.sv
+++ b/src-flattened/Encode.sv
@@ -1,0 +1,110 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Encodes the position of a '1' in the input vector into a binary number.
+// Example: A = "00100000" -> Z = "101".
+// Condition: exactly one bit of input vector A is '1'.
+
+module Encode #(
+	parameter int width = 8  // word width
+) (
+	input logic [width-1:0] A,  // input vector
+	output logic [$clog2(width)-1:0] Z  // enc. output
+);
+
+	localparam int n = width;
+	localparam int m = $clog2(width);
+
+	logic zv;
+
+	// example: n = 8, m = 3
+	//   Z[0] = A[7] || A[5] || A[3] || A[1]
+	//   Z[1] = A[7] || A[6] || A[3] || A[2]
+	//   Z[2] = A[7] || A[6] || A[5] || A[4]
+	// indices correspond to position of black nodes in Sklansky parallel-prefix
+	// algorithm
+	always_comb begin
+		for (int l = 1; l <= m; l++) begin : outbit
+			zv = 1'b0;
+			for (int k = 0; k < 2**(m-l); k++) begin
+				for (int i = 0; i < 2**(l-1); i++) begin
+					if (k * 2**l + 2**(l-1) + i < n) begin
+						zv |= A[k * 2**l + 2**(l-1) +i];
+					end
+				end
+			end
+			Z[l-1] = zv;
+		end
+	end
+
+endmodule
+
+
+
+module behavioural_Encode #(
+	parameter int width = 8  // word width
+) (
+	input logic [width-1:0] A,  // input vector
+	output logic [$clog2(width)-1:0] Z  // enc. output
+);
+	always_comb begin
+		for (int i = 0; i < width; i++ ) begin
+			if(A[i]) begin
+				Z = i;
+			end
+		end
+	end
+endmodule

--- a/src-flattened/FullAdder.sv
+++ b/src-flattened/FullAdder.sv
@@ -1,0 +1,94 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Should force the compiler to use a full-adder cell instead of simple logic
+// gates. Otherwise, a full-adder cell of the target library has to be
+// instantiated at this point (see second architecture).
+// {CO,S} = A + B +CI
+
+module FullAdder (
+	input  logic A,
+	input  logic B,
+	input  logic CI,  // operands
+	output logic S,
+	output logic CO  // sum and carry out
+);
+
+	logic [1:0] Auns, Buns, CIuns, Suns;  // unsigned temp
+
+	// type conversion: std_logic -> 2-bit unsigned
+	assign Auns  = {1'b0, A};
+	assign Buns  = {1'b0, B};
+	assign CIuns = {1'b0, CI};
+
+	// should force the compiler to use a full-adder cell
+	assign Suns = Auns + Buns + CIuns;
+
+	// type conversion: 2-bit unsigned -> std_logic
+	assign {CO, S} = Suns;
+
+endmodule
+
+
+module behavioural_FullAdder (
+	input  logic A,
+	input  logic B,
+	input  logic CI,  // operands
+	output logic S,
+	output logic CO  // sum and carry out
+);
+	assign {CO, S} = A + B + CI;
+endmodule

--- a/src-flattened/Gray2Bin.sv
+++ b/src-flattened/Gray2Bin.sv
@@ -1,0 +1,222 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Converts a number from Gray to binary representation. Corresponds to a
+// prefix problem in reversed bit order (compared to addition)
+
+module Gray2Bin #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] G,  // Gray input
+	output logic [width-1:0] B   // binary output
+);
+
+	logic [width-1:0] BT, GT;  // temp.
+
+	// reverse bit order of G
+	for (genvar i = 0; i < width; i++) begin : revG
+		assign GT[i] = G[width-i-1];
+	end
+
+
+	// convert Gray to binary using prefix XOR computation
+	PrefixXor #(
+		.width(width),
+		.speed(speed)
+	) prefix_xor (
+		.PI(GT),
+		.PO(BT)
+	);
+
+	// reverse bit order of B
+
+	for (genvar i = 0; i < width; i++) begin : revB
+		assign B[i] = BT[width-1-i];
+	end
+
+
+endmodule
+
+
+
+module behavioural_Gray2Bin #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] G,  // Gray input
+	output logic [width-1:0] B   // binary output
+);
+
+    for (genvar i = 0; i < width; i++)
+        assign B[i] = ^G[width-1:i];
+
+endmodule
+
+
+module PrefixXor #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+)  // performance parameter
+(
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO
+);  // propagate out
+
+	// prefix structure width and depth
+	localparam n = width;
+	localparam m = $clog2(width);
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		// Initialize PT
+		assign PT[n-1:0] = PI;
+
+		// Compute PT levels
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits_white
+					if ((k * 2 ** l + i) < n) begin
+						assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+					end
+				end
+
+				for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits_black
+					if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+				PT[(l-1)*n + k*2**l + 2**(l-1) + i] ^ PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end
+			end
+		end
+
+		// Assign output
+		assign PO = PT[(m+1)*n-1 : m*n];
+
+	end  // Brent-Kung parallel-prefix propagate-lookahead structure
+	else if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [2*m*n -1:0] PT;
+
+		// Initialize PT
+		assign PT[n-1:0] = PI;
+
+		// Compute levels1
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k * 2**l + 2**l -1) < n) begin : black
+					assign PT[l*n + k* 2**l + 2**l - 1] =
+								PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							  ^ PT[(l-1)*n + k* 2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+
+		// Compute levels2
+		for (genvar l = m + 1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l-1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end // bits
+				end // empty
+
+				if ((k* 2**(2*m -l) + 2**(2*m -l-1) -1) < n) begin : black
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] =
+								PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1] 
+							  ^ PT[(l-1)*n + k* 2**(2*m-l) -1];
+				end // black
+
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end // bits
+			end
+		end // levels2
+
+		// Assign output
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+
+	end  // Serial-prefix propagate-lookahead structure
+	else begin : slowPrefix
+		logic [n-1:0] PT;
+
+		// Initialize PT
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin
+			assign PT[i] = PI[i] ^ PT[i-1];
+		end
+
+		// Assign output
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/Inc.sv
+++ b/src-flattened/Inc.sv
@@ -1,0 +1,187 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Incrementer using parallel-prefix propagate-lookahead logic.
+// Z = A+1
+
+module Inc #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // result
+);
+
+	logic [width-1:0] PO;  // prefix propagate out
+
+	// calculate prefix output propagate signal
+	PrefixAnd #(
+		.width(width),
+		.speed(speed)
+	) prefix_and (
+		.PI(A),
+		.PO(PO)
+	);
+
+	// calculate result bits
+	assign Z = A ^ {PO[width-2:0], 1'b1};
+
+endmodule
+
+
+
+module behavioural_Inc #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // result
+);
+	assign Z = A + 1;
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/IncC.sv
+++ b/src-flattened/IncC.sv
@@ -1,0 +1,194 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Incrementer using parallel-prefix propagate-lookahead logic with:
+//   - carry-in (CI)
+//   - carry-out (CO)
+// {CO,Z} = A+CI
+
+module IncC #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operand
+	input  logic             CI,  // carry in
+	output logic [width-1:0] Z,   // result
+	output logic             CO   // carry out
+);
+
+	logic [width:0] AI;  // A inverted
+	logic [width:0] PO;  // prefix propagate out
+
+	// attach carry-in
+	assign AI = {A, CI};
+
+	// calculate prefix output propagate signal
+	PrefixAnd #(width+1, speed) prefix_and (
+		.PI(AI),
+		.PO(PO)
+	);
+
+	// calculate result and carry-out bits
+	assign Z  = A ^ PO[width-1:0];
+	assign CO = PO[width];
+
+endmodule
+
+
+module behavioural_IncC #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operand
+	input  logic             CI,  // carry in
+	output logic [width-1:0] Z,   // result
+	output logic             CO   // carry out
+);
+	assign {CO,Z} = A + CI;
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/IncDec.sv
+++ b/src-flattened/IncDec.sv
@@ -1,0 +1,190 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Incrementer-decrementer using parallel-prefix propagate-lookahead logic.
+// Z = DEC ? A-1: A+1
+
+module IncDec #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operand
+	input  logic             DEC,  // decrement enable
+	output logic [width-1:0] Z     // result
+);
+
+	logic [width-1:0] AI;  // A inverted
+	logic [width-1:0] PO;  // prefix propagate out
+
+	// invert A for decrement
+	assign AI = A ^ {width{DEC}};
+
+	// calculate prefix output propagate signal
+	PrefixAnd #(width, speed) prefix_and (
+		.PI(AI),
+		.PO(PO)
+	);
+
+	// calculate result bits
+	assign Z = A ^ {PO[width-2:0], 1'b1};
+
+endmodule
+
+
+
+module behavioural_IncDec #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operand
+	input  logic             DEC,  // decrement enable
+	output logic [width-1:0] Z     // result
+);
+	assign Z = DEC? A-1: A+1;
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/IncDecC.sv
+++ b/src-flattened/IncDecC.sv
@@ -1,0 +1,197 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Incrementer-decrementer using parallel-prefix carry-lookahead logic with:
+//   - carry-in (CI)
+//   - carry-out (CO)
+// {CO,Z} = DEC ? A-CI: A+CI
+
+module IncDecC #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operand
+	input  logic             CI,   // carry in
+	input  logic             DEC,  // decrement enable
+	output logic [width-1:0] Z,    // result
+	output logic             CO    // carry out
+);
+
+	logic [width:0] AI;  // A inverted
+	logic [width:0] PO;  // prefix propagate out
+
+	// invert A for decrement and attach carry-in
+	assign AI = {A ^ {DEC, {width - 1{DEC}}}, CI};
+
+	// calculate prefix output propagate signal
+	PrefixAnd #(width + 1, speed) prefix_and (
+		.PI(AI),
+		.PO(PO)
+	);
+
+	// calculate result and carry-out bits
+	assign Z  = A ^ PO[width-1:0];
+	assign CO = PO[width];
+
+endmodule
+
+
+
+module behavioural_IncDecC #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operand
+	input  logic             CI,   // carry in
+	input  logic             DEC,  // decrement enable
+	output logic [width-1:0] Z,    // result
+	output logic             CO    // carry out
+);
+	assign {CO,Z} = DEC? A-CI : A+CI;
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/IncGray.sv
+++ b/src-flattened/IncGray.sv
@@ -1,0 +1,286 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Incrementer for Gray numbers using parallel-prefix propagate-lookahead
+// logic.
+// Bases on the following algorithm:
+//   P = A(n-1) xor A(n-2) xor ... xor A(0)
+//   Z(0) = A(0) xnor P
+//   Z(i) = A(i) xor (A(i-1) and not A(i-2) and not A(i-3) ...
+//                           and not A(0) and P)              ; i = 1, ..., n-2
+//   Z(n-1) = A(n-1) xor (not A(n-3) and not A(n-4) ... and not A(0) and P)
+
+module IncGray #(
+	parameter int width = 16,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // result
+);
+
+	logic [width-2:0] PI;  // prefix prop. in
+	logic [width-2:0] PO;  // prefix prop. out
+	logic             P;  // parity bit
+	logic [width-1:2] T1;  // temp.
+	logic [width-1:0] T2;  // temp.
+
+	// calculate parity bit P
+	RedXor #(width) parity (
+		.A(A),
+		.Z(P)
+	);
+
+	// calculate prefix input propagate signal (PI = not A(i))
+	assign PI[width-2:1] = ~A[width-3:0];
+
+	// feed slow P signal into prefix circuit for slow architecture
+	if (speed == lau_pkg::SLOW) begin
+		assign PI[0] = P;
+	end else begin
+		assign PI[0] = 1'b1;
+	end
+
+	// calculate prefix output prop. signal (PO = not A(i-2) ... and not A(0))
+	PrefixAnd #(width-1, speed) prefix_and (
+		.PI(PI),
+		.PO(PO)
+	);
+
+	// calculate (A and PO)
+	assign T1[width-2:2] = A[width-3:1] & PO[width-3:1];
+	// special case
+	assign T1[width-1] = PO[width-2];
+
+	// calculate (T1 and P) in fast architecture
+	for (genvar i = width-1; i >= 2; i--) begin
+		if (speed == lau_pkg::SLOW) begin
+			assign T2[i] = T1[i];
+		end else begin
+			assign T2[i] = T1[i] & P;
+		end
+	end
+
+	// special cases
+	assign T2[1] = A[0] & P;
+	assign T2[0] = ~P;
+
+	// calculate result bits
+	assign Z = A ^ T2;
+
+endmodule
+
+
+
+module behavioural_IncGray #(
+	parameter int width = 16,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // result
+);
+	logic [width-1:0] Abin, Zbin;
+	behavioural_Gray2Bin #(width, speed) i_gray2bin (
+		.G(A),
+		.B(Abin)
+	);
+	
+	assign Zbin = Abin + 1;
+
+	behavioural_Bin2Gray #(width) i_bin2gray (
+		.B(Zbin),
+		.G(Z)
+	);
+
+endmodule
+
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule
+
+module RedXor #(
+	parameter int width = 8  // word width
+) (
+	input logic [width-1:0] A,  // input vector
+	output logic Z  // output bit
+);
+
+	logic zv;
+
+	// XOR all bits
+	// behavioral description used (well handled by all synthesizers)
+	always_comb begin
+		zv = A[0];
+		for (int i = 1; i < width; i++) begin
+			zv ^= A[i];
+		end
+		Z = zv;
+	end
+
+endmodule
+
+module behavioural_Bin2Gray #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] B,  // binary input
+	output logic [width-1:0] G   // Gray output
+);
+
+	assign G = B ^ (B >> 1);
+
+endmodule
+
+module behavioural_Gray2Bin #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] G,  // Gray input
+	output logic [width-1:0] B   // binary output
+);
+
+    for (genvar i = 0; i < width; i++)
+        assign B[i] = ^G[width-1:i];
+
+endmodule

--- a/src-flattened/IncGrayC.sv
+++ b/src-flattened/IncGrayC.sv
@@ -1,0 +1,290 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Incrementer for Gray numbers using parallel-prefix propagate-lookahead
+// logic with:
+//   - carry-in (CI)
+// Bases on the following algorithm:
+//   P = A(n-1) xor A(n-2) xor ... xor A(0)
+//   Z(0) = A(0) xnor P
+//   Z(i) = A(i) xor (A(i-1) and not A(i-2) and not A(i-3) ...
+//                           and not A(0) and P)              ; i = 1, ..., n-2
+//   Z(n-1) = A(n-1) xor (not A(n-3) and not A(n-4) ... and not A(0) and P)
+
+module IncGrayC #(
+	parameter int width = 16,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operand
+	input  logic             CI,  // carry in
+	output logic [width-1:0] Z    // result
+);
+
+	logic [width-2:0] PI;  // prefix prop. in
+	logic [width-2:0] PO;  // prefix prop. out
+	logic P, PT;  // parity bit
+	logic [width-1:2] T1;  // temp.
+	logic [width-1:0] T2;  // temp.
+
+	// calculate parity bit P
+	RedXor #(width) parity (
+		.A(A),
+		.Z(P)
+	);
+
+	// calculate prefix input propagate signal (PI = not A(i))
+	assign PI[width-2:1] = ~A[width-3:0];
+
+	// feed slow P signal into prefix circuit for slow architecture
+	// consider CI here for bits 2, ..., n-1
+	if (speed == lau_pkg::SLOW) begin
+		assign PI[0] = P & CI;
+	end else begin
+		assign PI[0] = CI;
+	end
+
+	// calculate prefix output prop. signal (PO = not A(i-2) ... and not A(0))
+	PrefixAnd #(width-1, speed) prefix_and (
+		.PI(PI),
+		.PO(PO)
+	);
+
+	// calculate (A and PO)
+	assign T1[width-2:2] = A[width-3:1] & PO[width-3:1];
+	// special case
+	assign T1[width-1] = PO[width-2];
+
+	// calculate (T1 and P) in fast architecture
+	for (genvar i = width-1; i >= 2; i--) begin
+		if (speed == lau_pkg::SLOW) begin
+			assign T2[i] = T1[i];
+		end else begin
+			assign T2[i] = T1[i] & P;
+		end
+	end
+
+	// special cases, consider CI hier for bits 0 and 1
+	assign T2[1] = A[0] & P & CI;
+	assign T2[0] = ~(P | ~CI);
+
+	// calculate result bits
+	assign Z = A ^ T2;
+
+endmodule
+
+
+
+module behavioural_IncGrayC #(
+	parameter int width = 16,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,   // operand
+	input  logic             CI,  // carry in
+	output logic [width-1:0] Z    // result
+);
+	logic [width-1:0] Abin, Zbin;
+	behavioural_Gray2Bin #(width, speed) i_gray2bin (
+		.G(A),
+		.B(Abin)
+	);
+	
+	assign Zbin = Abin + CI;
+
+	behavioural_Bin2Gray #(width) i_bin2gray (
+		.B(Zbin),
+		.G(Z)
+	);
+
+endmodule
+
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule
+
+module RedXor #(
+	parameter int width = 8  // word width
+) (
+	input logic [width-1:0] A,  // input vector
+	output logic Z  // output bit
+);
+
+	logic zv;
+
+	// XOR all bits
+	// behavioral description used (well handled by all synthesizers)
+	always_comb begin
+		zv = A[0];
+		for (int i = 1; i < width; i++) begin
+			zv ^= A[i];
+		end
+		Z = zv;
+	end
+
+endmodule
+
+module behavioural_Bin2Gray #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] B,  // binary input
+	output logic [width-1:0] G   // Gray output
+);
+
+	assign G = B ^ (B >> 1);
+
+endmodule
+
+module behavioural_Gray2Bin #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] G,  // Gray input
+	output logic [width-1:0] B   // binary output
+);
+
+    for (genvar i = 0; i < width; i++)
+        assign B[i] = ^G[width-1:i];
+
+endmodule

--- a/src-flattened/LeadOneDet.sv
+++ b/src-flattened/LeadOneDet.sv
@@ -1,0 +1,214 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Detection of leading ones. Output vector indicates position of the first
+// '0' (starting at MSB).
+// Example: A = "111010" -> Z = "000100".
+// Use the `Encode' component for encoding the output (-> Z = "010").
+
+module LeadOneDet #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // LOD output
+);
+
+	logic [width-1:0] PI;  // prefix prop. in
+	logic [width-1:0] PO;  // prefix prop. out
+	logic [width-1:0] PIT;  // temp.
+	logic [width-1:0] POT;  // temp.
+
+	// calculate prefix propagate in signals
+	assign PI = A;
+
+	// reverse bit order of PI
+	for (genvar i = width - 1; i >= 0; i--) begin
+		assign PIT[i] = PI[width-i-1];
+	end
+
+	// solve reverse prefix problem for leading-ones detection
+	// (example: "111010" -> "111100")
+	PrefixAnd #(width, speed) prefix_and (
+		.PI(PIT),
+		.PO(POT)
+	);
+
+	// reverse bit order of PO
+	for (genvar i = width - 1; i >= 0; i--) begin
+		assign PO[i] = POT[width-i-1];
+	end
+
+	// code output: only bit indicating position of first '0' is '1'
+	// (example: "111010" -> "000100")
+	assign Z[width-1]   = ~A[width-1];
+	assign Z[width-2:0] = PO[width-1:1] & ~A[width-2:0];
+
+endmodule
+
+
+
+module behavioural_LeadOneDet #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // LOD output
+);
+	logic [width-1:0] idx;
+	always_comb begin
+		idx = width;
+		for (int i = 0; i < width ; i++ ) begin
+			if(A[i] == 1'b0) begin
+				idx = i;
+			end
+		end
+		Z = 1'b1 << idx;
+	end
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/LeadSignDet.sv
+++ b/src-flattened/LeadSignDet.sv
@@ -1,0 +1,222 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Detection of leading signs (i.e. leading-zeroes/ones detection for signed
+// numbers). Output vector indicates position of the first bit which differs
+// from the sign (starting at MSB).
+// Examples: A = "000101" -> Z = "000100", A = "111010" -> Z = "000100".
+// Use the `Encode' component for encoding the output (-> Z = "010").
+
+module LeadSignDet #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // LSD output
+);
+
+	logic [width-2:0] PI;  // prefix prop. in
+	logic [width-2:0] PO;  // prefix prop. out
+	logic [width-2:0] PIT;  // temp.
+	logic [width-2:0] POT;  // temp.
+
+	// calculate prefix propagate in signals (depends on sign)
+	for (genvar i = width - 2; i >= 0; i--) begin
+		assign PI[i] = ~(A[width-1] ^ A[i]);
+	end
+
+	// reverse bit order of PI
+	for (genvar i = width - 2; i >= 0; i--) begin
+		assign PIT[i] = PI[width-i-2];
+	end
+
+	// solve reverse prefix problem for leading-signs detection
+	// (example: "000101" -> "111100")
+	PrefixAnd #(width - 1, speed) prefix_and (
+		.PI(PIT),
+		.PO(POT)
+	);
+
+	// reverse bit order of PO
+	for (genvar i = width - 2; i >= 0; i--) begin
+		assign PO[i] = POT[width-i-2];
+	end
+
+	// code output: only bit indicating position of first non-sign is '1'
+	// (example: "000101" -> "000100")
+	assign Z[width-1] = 1'b0;
+	assign Z[width-2] = A[width-1] ^ A[width-2];
+	for (genvar i = width - 3; i >= 0; i--) begin
+		assign Z[i] = PO[i+1] & (A[width-1] ^ A[i]);
+	end
+
+endmodule
+
+
+
+module behavioural_LeadSignDet #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // LSD output
+);
+	logic msb;
+	logic [width-1:0] idx;
+	always_comb begin
+		msb = A[width-1];
+		idx = width;
+		for (int i = 0; i < width ; i++ ) begin
+			if(A[i] == ~msb) begin
+				idx = i;
+			end
+		end
+		Z = 1'b1 << idx;
+	end
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/LeadZeroDet.sv
+++ b/src-flattened/LeadZeroDet.sv
@@ -1,0 +1,216 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Detection of leading zeroes. Output vector indicates position of the first
+// '1' (starting at MSB).
+// Example: A = "000101" -> Z = "000100".
+// Use the `Encode' component for encoding the output (-> Z = "010").
+
+module LeadZeroDet #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // LZD output
+);
+
+	logic [width-1:0] PI;  // prefix prop. in
+	logic [width-1:0] PO;  // prefix prop. out
+	logic [width-1:0] PIT;  // temp.
+	logic [width-1:0] POT;  // temp.
+
+	// calculate prefix propagate in signals
+	assign PI = ~A;
+
+	// reverse bit order of PI
+	for (genvar i = width - 1; i >= 0; i--) begin
+		assign PIT[i] = PI[width-i-1];
+	end
+
+	// solve reverse prefix problem for leading-zeroes detection
+	// (example: "000101" -> "111100")
+	PrefixAnd #(width, speed) prefix_and (
+		.PI(PIT),
+		.PO(POT)
+	);
+
+	// reverse bit order of PO
+	for (genvar i = width - 1; i >= 0; i--) begin
+		assign PO[i] = POT[width-i-1];
+	end
+
+	// code output: only bit indicating position of first '1' is '1'
+	// (example: "000101" -> "000100")
+	assign Z[width-1] = A[width-1];
+	for (genvar i = width - 2; i >= 0; i--) begin
+		assign Z[i] = PO[i+1] & A[i];
+	end
+
+endmodule
+
+
+
+module behavioural_LeadZeroDet #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // LZD output
+);
+	logic [width-1:0] idx;
+	always_comb begin
+		idx = width;
+		for (int i = 0; i < width ; i++ ) begin
+			if(A[i] == 1'b1) begin
+				idx = i;
+			end
+		end
+		Z = 1'b1 << idx;
+	end
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/Log2.sv
+++ b/src-flattened/Log2.sv
@@ -1,0 +1,271 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Computes integer logarithm to base 2. 
+// Z = floor(log A))
+// Example: A = "00010110" -> Z = "100".
+
+module Log2 #(
+    parameter int width = 8,     // word width
+    parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+    input logic [width-1:0] A,  // operand
+    output logic [$clog2(width)-1:0] Z  // result
+);
+
+    logic [width-1:0] ZT;  // temp.
+
+    // leading zero detection (i.e. most significant '1')
+    LeadZeroDet #(width, speed) loz (
+        .A(A),
+        .Z(ZT)
+    );
+
+    // binary encode
+    Encode #(width) enc (
+        .A(ZT),
+        .Z(Z)
+    );
+
+endmodule
+
+
+
+module behavioural_Log2 #(
+    parameter int width = 8,     // word width
+    parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+    input logic [width-1:0] A,  // operand
+    output logic [$clog2(width)-1:0] Z  // result
+);
+    always_comb begin
+		Z = '0;
+		for (int i = 0; i < width ; i++ ) begin
+			if(A[i] == 1'b1) begin
+				Z = i;
+			end
+		end
+	end
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule
+
+module LeadZeroDet #(
+	parameter int width = 8,     // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // LZD output
+);
+
+	logic [width-1:0] PI;  // prefix prop. in
+	logic [width-1:0] PO;  // prefix prop. out
+	logic [width-1:0] PIT;  // temp.
+	logic [width-1:0] POT;  // temp.
+
+	// calculate prefix propagate in signals
+	assign PI = ~A;
+
+	// reverse bit order of PI
+	for (genvar i = width - 1; i >= 0; i--) begin
+		assign PIT[i] = PI[width-i-1];
+	end
+
+	// solve reverse prefix problem for leading-zeroes detection
+	// (example: "000101" -> "111100")
+	PrefixAnd #(width, speed) prefix_and (
+		.PI(PIT),
+		.PO(POT)
+	);
+
+	// reverse bit order of PO
+	for (genvar i = width - 1; i >= 0; i--) begin
+		assign PO[i] = POT[width-i-1];
+	end
+
+	// code output: only bit indicating position of first '1' is '1'
+	// (example: "000101" -> "000100")
+	assign Z[width-1] = A[width-1];
+	for (genvar i = width - 2; i >= 0; i--) begin
+		assign Z[i] = PO[i+1] & A[i];
+	end
+
+endmodule
+
+module Encode #(
+	parameter int width = 8  // word width
+) (
+	input logic [width-1:0] A,  // input vector
+	output logic [$clog2(width)-1:0] Z  // enc. output
+);
+
+	localparam int n = width;
+	localparam int m = $clog2(width);
+
+	logic zv;
+
+	// example: n = 8, m = 3
+	//   Z[0] = A[7] || A[5] || A[3] || A[1]
+	//   Z[1] = A[7] || A[6] || A[3] || A[2]
+	//   Z[2] = A[7] || A[6] || A[5] || A[4]
+	// indices correspond to position of black nodes in Sklansky parallel-prefix
+	// algorithm
+	always_comb begin
+		for (int l = 1; l <= m; l++) begin : outbit
+			zv = 1'b0;
+			for (int k = 0; k < 2**(m-l); k++) begin
+				for (int i = 0; i < 2**(l-1); i++) begin
+					if (k * 2**l + 2**(l-1) + i < n) begin
+						zv |= A[k * 2**l + 2**(l-1) +i];
+					end
+				end
+			end
+			Z[l-1] = zv;
+		end
+	end
+
+endmodule

--- a/src-flattened/MulAddSgn.sv
+++ b/src-flattened/MulAddSgn.sv
@@ -1,0 +1,491 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Multiplier-adder for signed numbers (Baugh-Wooley). First multiplies two
+// numbers, then adds an additional operand to the result.
+// P = (X*Y) +A
+
+module MulAddSgn #(
+	parameter int              widthX = 8,             // word width of XS, XC (<= widthY)
+	parameter int              widthY = 8,             // word width of Y
+	parameter int              widthA = 20,            // word width of A (>= widthX+widthY)
+	parameter lau_pkg::speed_e speed  = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [widthX-1:0] X,  // multiplier
+	input  logic [widthY-1:0] Y,  // multiplicand
+	input  logic [widthA-1:0] A,  // augend
+	output logic [widthA-1:0] P   // product
+);
+
+	logic [(widthX+2)*(widthX+widthY)-1:0] PP;  // partial products
+	logic [widthA-1:0] ST1, CT1, ST2, CT2;  // intermediate sum/carry bits
+
+	// generation of partial products
+	MulPPGenSgn #(widthX, widthY) ppGen (
+		.X (X),
+		.Y (Y),
+		.PP(PP)
+	);
+
+	// carry-save addition of partial products
+	AddMopCsv #(widthX+widthY, widthX+2, speed) csvAdd1 (
+		.A (PP),
+		.S (ST1[widthX+widthY-1:0]),
+		.C (CT1[widthX+widthY-1:0])
+	);
+
+	// extend
+	always_comb begin
+		if (widthA > widthX + widthY) begin
+			ST1[widthX+widthY] = ~ST1[widthX+widthY-1];
+			ST1[widthA-1:widthX+widthY+1] = '0;
+			for (int i = widthX + widthY; i < widthA ; i++) CT1[i] = 1'b1;
+		end
+	end
+
+	// carry-save addition of augend
+	AddCsv #(widthA) csvAdd2 (
+		.A1(A),
+		.A2(CT1),
+		.A3(ST1),
+		.S (ST2),
+		.C (CT2)
+	);
+
+	// final carry-propagate addition
+	Add #(widthA, speed) cpAdd (
+		.A(ST2),
+		.B(CT2),
+		.S(P)
+	);
+
+endmodule
+
+
+
+module behavioural_MulAddSgn #(
+	parameter int              widthX = 8,             // word width of XS, XC (<= widthY)
+	parameter int              widthY = 8,             // word width of Y
+	parameter int              widthA = 20,            // word width of A (>= widthX+widthY)
+	parameter lau_pkg::speed_e speed  = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [widthX-1:0] X,  // multiplier
+	input  logic [widthY-1:0] Y,  // multiplicand
+	input  logic [widthA-1:0] A,  // augend
+	output logic [widthA-1:0] P   // product
+);
+	assign P = (signed'(X) * signed'(Y)) + signed'(A);
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module Add #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	// Function: Binary adder using parallel-prefix carry-lookahead logic.
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// Internal signals for unsigned operands
+	logic [width-1:0] Auns, Buns, Suns;
+
+	// default ripple-carry adder as slow implementation
+	if (speed == lau_pkg::SLOW) begin
+		// type conversion: std_logic_vector -> unsigned
+		assign Auns = A;
+		assign Buns = B;
+
+		// addition
+		assign Suns = Auns + Buns;
+
+		// type conversion: unsigned -> std_logic_vector
+		assign S = Suns;
+	end else begin
+		// parallel-prefix adders as medium and fast implementations
+
+		// calculate prefix input generate/propagate signals
+		assign GI = A & B;
+		assign PI = A | B;
+		// calculate adder propagate signals (PT = A xor B)
+		assign PT = ~GI & PI;
+
+		// calculate prefix output generate/propagate signals
+		PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+		) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GO),
+			.PO(PO)
+		);
+
+		// calculate sum bits
+		assign S = PT ^ {GO[width-2:0], 1'b0};
+	end
+endmodule
+
+module MulPPGenSgn #(
+	parameter int widthX = 8,  // word width of X
+	parameter int widthY = 8   // word width of Y
+) (
+	input logic [widthX-1:0] X,  // multiplier
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [(widthX+2)*(widthX+widthY)-1:0] PP  // partial products
+);
+
+	localparam int unsigned widthP = widthX + widthY;  // width of single part. prod.
+
+	always_comb begin
+		logic [(widthX+2)*widthP-1:0] ppt;  // partial product vector
+
+		// Initialize ppt to all zeros
+		ppt = '0;
+
+		// Generate partial products x(i)y(k)
+		for (int i = 0; i < widthX-1; i++) begin
+			for (int k = 0; k < widthY-1; k++) begin
+				ppt[i*widthP+i+k] = X[i] & Y[k];
+			end
+			ppt[i*widthP+i+widthY-1] = ~X[i] & Y[widthY-1];
+		end
+
+		for (int k = 0; k < widthY-1; k++) begin
+			ppt[(widthX-1)*widthP+(widthX-1)+k] = X[widthX-1] & ~Y[k];
+		end
+		ppt[(widthX-1)*widthP+(widthX-1)+widthY-1] = X[widthX-1] & Y[widthY-1];
+
+		// Generate correction terms
+		ppt[(widthX+1)*widthP-2] = ~X[widthX-1];
+		ppt[widthX*widthP+widthX-1] = X[widthX-1];
+		ppt[(widthX+2)*widthP-1] = 1'b1;
+		ppt[(widthX+2)*widthP-2] = ~Y[widthY-1];
+		ppt[(widthX+1)*widthP+widthY-1] = Y[widthY-1];
+
+		// Assign output
+		PP = ppt;
+	end
+
+endmodule
+
+module AddCsv #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A1,  // operands
+	input  logic [width-1:0] A2,
+	input  logic [width-1:0] A3,
+	output logic [width-1:0] S,   // sum / carry vector
+	output logic [width-1:0] C
+);
+
+	logic [width-1:0] CT;  // unshifted output carries
+
+	// carry-save addition using full-adders
+	for (genvar i = 0; i < width; i++) begin : bits
+		FullAdder fa (
+		.A  (A1[i]),
+		.B  (A2[i]),
+		.CI (A3[i]),
+		.S  (S[i] ),
+		.CO (CT[i])
+		);
+	end
+
+	// rotate output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule

--- a/src-flattened/MulAddUns.sv
+++ b/src-flattened/MulAddUns.sv
@@ -1,0 +1,475 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Multiplier-adder for unsigned numbers (Brown). First multiplies two numbers,
+// then adds an additional operand to the result.
+// P = (X*Y) +A
+
+module MulAddUns #(
+	parameter int              widthX = 8,             // word width of XS, XC (<= widthY)
+	parameter int              widthY = 8,             // word width of Y
+	parameter int              widthA = 20,            // word width of A (>= widthX+widthY)
+	parameter lau_pkg::speed_e speed  = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [widthX-1:0] X,  // multiplier
+	input  logic [widthY-1:0] Y,  // multiplicand
+	input  logic [widthA-1:0] A,  // augend
+	output logic [widthA-1:0] P   // product
+);
+
+	logic [widthX*(widthX+widthY)-1:0] PP;  // partial products
+	logic [widthA-1:0] ST1, CT1, ST2, CT2;  // intermediate sum/carry bits
+
+	// generation of partial products
+	MulPPGenUns #(widthX, widthY) ppGen (
+		.X (X),
+		.Y (Y),
+		.PP(PP)
+	);
+
+	// carry-save addition of partial products
+	AddMopCsv #(widthX + widthY, widthX, speed) csvAdd1 (
+		.A (PP),
+		.S (ST1[widthX+widthY-1:0]),
+		.C (CT1[widthX+widthY-1:0])
+	);
+
+	// extend
+	for (genvar i = widthA - 1; i >= widthX + widthY; i--) begin
+		assign ST1[i] = 1'b0;
+		assign CT1[i] = 1'b0;
+	end
+
+	// carry-save addition of augend
+	AddCsv #(widthA) csvAdd2 (
+		.A1(A),
+		.A2(CT1),
+		.A3(ST1),
+		.S (ST2),
+		.C (CT2)
+	);
+
+	// final carry-propagate addition
+	Add #(widthA, speed) cpAdd (
+		.A(ST2),
+		.B(CT2),
+		.S(P)
+	);
+
+endmodule
+
+
+
+module behavioural_MulAddUns #(
+	parameter int              widthX = 8,             // word width of XS, XC (<= widthY)
+	parameter int              widthY = 8,             // word width of Y
+	parameter int              widthA = 20,            // word width of A (>= widthX+widthY)
+	parameter lau_pkg::speed_e speed  = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [widthX-1:0] X,  // multiplier
+	input  logic [widthY-1:0] Y,  // multiplicand
+	input  logic [widthA-1:0] A,  // augend
+	output logic [widthA-1:0] P   // product
+);
+	assign P = (X * Y) + A;
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module Add #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	// Function: Binary adder using parallel-prefix carry-lookahead logic.
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// Internal signals for unsigned operands
+	logic [width-1:0] Auns, Buns, Suns;
+
+	// default ripple-carry adder as slow implementation
+	if (speed == lau_pkg::SLOW) begin
+		// type conversion: std_logic_vector -> unsigned
+		assign Auns = A;
+		assign Buns = B;
+
+		// addition
+		assign Suns = Auns + Buns;
+
+		// type conversion: unsigned -> std_logic_vector
+		assign S = Suns;
+	end else begin
+		// parallel-prefix adders as medium and fast implementations
+
+		// calculate prefix input generate/propagate signals
+		assign GI = A & B;
+		assign PI = A | B;
+		// calculate adder propagate signals (PT = A xor B)
+		assign PT = ~GI & PI;
+
+		// calculate prefix output generate/propagate signals
+		PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+		) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GO),
+			.PO(PO)
+		);
+
+		// calculate sum bits
+		assign S = PT ^ {GO[width-2:0], 1'b0};
+	end
+endmodule
+
+module AddCsv #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A1,  // operands
+	input  logic [width-1:0] A2,
+	input  logic [width-1:0] A3,
+	output logic [width-1:0] S,   // sum / carry vector
+	output logic [width-1:0] C
+);
+
+	logic [width-1:0] CT;  // unshifted output carries
+
+	// carry-save addition using full-adders
+	for (genvar i = 0; i < width; i++) begin : bits
+		FullAdder fa (
+		.A  (A1[i]),
+		.B  (A2[i]),
+		.CI (A3[i]),
+		.S  (S[i] ),
+		.CO (CT[i])
+		);
+	end
+
+	// rotate output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule
+
+module MulPPGenUns #(
+	parameter widthX = 8,  // word width of X
+	parameter widthY = 8
+)  // word width of Y
+(
+	input logic [widthX-1:0] X,  // multiplier
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX*(widthX+widthY)-1:0] PP
+);
+
+	// width of single part. prod.
+	localparam widthP = widthX + widthY;
+
+	logic [widthX*widthP-1:0] ppt;  // partial products
+
+	always_comb begin : ppGen
+		ppt = '0;  // partial products
+
+		// partial products x(i)y(k)
+		for (int i = 0; i < widthX; i++) begin
+			for (int k = 0; k < widthY; k++) begin
+				ppt[i*widthP+i+k] = X[i] & Y[k];
+			end
+		end
+
+		PP = ppt;
+	end
+
+endmodule
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule

--- a/src-flattened/MulCsvSgn.sv
+++ b/src-flattened/MulCsvSgn.sv
@@ -1,0 +1,257 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Multiplier for signed numbers with one input operand and the
+// result in carry-save number representation (Brown). First adds two
+// numbers, then multiplies the result with the multiplicand without
+// performing final addition. Result is only valid if sum of
+// carry-save input operands does not overflow.
+// The exact bit-pattern of S and C change depending on the structure 
+// of the implemented tree because operands are commutative and can be added in
+// different parts of the tree, contributing either to S or C. 
+// The only guarantee is that S+C is the same.
+
+module MulCsvSgn #(
+	parameter int              widthX = 8,             // word width of XS, XC (<= widthY)
+	parameter int              widthY = 8,             // word width of Y
+	parameter lau_pkg::speed_e speed  = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [widthX-1:0] XS, // multiplier
+	input  logic [widthX-1:0] XC, // multiplier
+	input  logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX+widthY-1:0] PS, // sum
+	output logic [widthX+widthY-1:0] PC  // carry
+);
+
+	logic [(widthX+1)*(widthX+widthY)-1:0] PP;  // partial products
+
+	// generation of partial products
+	AddMulPPGenSgn #(widthX, widthY) ppGen (
+		.XS(XS),
+		.XC(XC),
+		.Y (Y),
+		.PP(PP)
+	);
+
+	// carry-save addition of partial products
+	AddMopCsv #(widthX+widthY, widthX+1, speed) csvAdd (
+		.A (PP),
+		.S (PS),
+		.C (PC)
+	);
+
+endmodule
+
+
+module AddMulPPGenSgn #(
+	parameter int widthX  = 8, // word width of XS, XC
+	parameter int widthY  = 8, // word width of Y
+	localparam int widthP = widthX+widthY
+) (
+	input logic [widthX-1:0] XS,  // multipliers
+	input logic [widthX-1:0] XC,
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [(widthX+1)*(widthP)-1:0] PP  // partial products
+);
+
+	logic [widthX-1:0] M1, M2;  // recoded multiplier
+	logic [widthY+1:0] YT, YBT;  // expanded Y
+
+	// recode multiplier
+	assign M1 = XS ^ XC;
+	assign M2 = XS & XC;
+
+	// expand Y (used for term 2y)
+	assign YT  = { Y[widthY-1],  Y[widthY-1:0], 1'b0};
+	assign YBT = {~Y[widthY-1], ~Y[widthY-1:0], 1'b0};
+
+	logic [(widthX+1)*widthP-1:0] ppt;
+
+	// partial product generation
+	always_comb begin
+		ppt = 0;
+		for (int i = 0; i < widthX-1; i++) begin
+			for (int k = 0; k <= widthY; k++) begin
+				ppt[i*widthP+i+k] = (M1[i] & YT[k+1]) | (M2[i] & YT[k]);
+			end
+			for (int k = widthY+1; k <= (widthY+widthX-i-1); k++) begin
+				ppt[i*widthP+i+k] = (M1[i] | M2[i]) & YT[widthY];
+			end
+		end
+		for (int k = 0; k <= widthY; k++) begin
+			ppt[(widthX-1)*widthP+widthX-1+k] = (M1[widthX-1] & YBT[k+1]) | (M2[widthX-1] & YBT[k]);
+		end
+		ppt[widthX*widthP+widthX-1] = M1[widthX-1];
+		ppt[widthX*widthP+widthX  ] = M2[widthX-1];
+		PP = ppt;
+	end
+
+endmodule
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule

--- a/src-flattened/MulCsvUns.sv
+++ b/src-flattened/MulCsvUns.sv
@@ -1,0 +1,249 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Multiplier for unsigned numbers with one input operand and the
+// result in carry-save number representation (Brown). First adds two
+// numbers, then multiplies the result with the multiplicand without
+// performing final addition. Result is only valid if sum of
+// carry-save input operands does not overflow.
+// The exact bit-pattern of S and C change depending on the structure 
+// of the implemented tree because operands are commutative and can be added in
+// different parts of the tree, contributing either to S or C. 
+// The only guarantee is that S+C is the same.
+
+module MulCsvUns #(
+	parameter int widthX = 8,     // word width of XS, XC (<= widthY)
+	parameter int widthY = 8,     // word width of Y
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [widthX-1:0] XS,  // multiplier
+	input logic [widthX-1:0] XC,  // multiplier
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX+widthY-1:0] PS,  // sum
+	output logic [widthX+widthY-1:0] PC  // carry
+);
+
+	logic [widthX*(widthX+widthY)-1:0] PP;  // partial products
+	logic [widthX+widthY-1:0] ST, CT;  // intermediate sum/carry bits
+
+	// generation of partial products
+	AddMulPPGenUns #(widthX, widthY) ppGen (
+		.XS(XS),
+		.XC(XC),
+		.Y (Y),
+		.PP(PP)
+	);
+
+	// carry-save addition of partial products
+	AddMopCsv #(widthX+widthY, widthX, speed) csvAdd (
+		.A (PP),
+		.S (PS),
+		.C (PC)
+	);
+
+endmodule
+
+
+module AddMulPPGenUns #(
+	parameter int widthX = 8,  // word width of XS, XC
+	parameter int widthY = 8,  // word width of Y
+	localparam int widthP = widthX+widthY
+) (
+	input logic [widthX-1:0] XS,  // multipliers
+	input logic [widthX-1:0] XC,
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX*(widthP)-1:0] PP  // partial products
+);
+
+	logic [widthX-1:0] M1, M2;  // recoded multiplier
+	logic [widthY+1:0] YT;  // expanded Y
+
+	// recode multiplier
+	assign M1 = XS ^ XC;
+	assign M2 = XS & XC;
+
+	// expand Y (used for term 2y)
+	assign YT = {1'b0, Y, 1'b0};
+
+	logic [widthX*widthP-1:0] ppt;
+
+	// partial product generation
+	always_comb begin
+		ppt = 0;
+		for (int i = 0; i < widthX; i++) begin
+			for (int k = 0; k <= widthY; k++) begin
+				ppt[i*widthP+i+k] = (M1[i] & YT[k+1]) | (M2[i] & YT[k]);
+			end
+		end
+		PP = ppt;
+	end
+
+endmodule
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule

--- a/src-flattened/MulPPGenSgn.sv
+++ b/src-flattened/MulPPGenSgn.sv
@@ -1,0 +1,112 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Partial-product generator for signed multiplier (Baugh-Wooley).
+//
+// Partial products and correction terms for 4x4-bit signed multiplication:
+//
+//      0         0         0         0 ~x(0)y(3)  x(0)y(2)  x(0)y(1)  x(0)y(0)
+//      0         0         0 ~x(1)y(3)  x(1)y(2)  x(1)y(1)  x(1)y(0)         0
+//      0         0 ~x(2)y(3)  x(2)y(2)  x(2)y(1)  x(2)y(0)         0         0
+//      0  x(3)y(3) x(3)~y(2) x(3)~y(1) x(3)~y(0)         0         0         0
+//      0     ~x(3)         0         0      x(3)         0         0         0
+//      1     ~y(3)         0         0      y(3)         0         0         0
+////////////////////////////////////////////////////////////////////////////////
+//   p(7)      p(6)      p(5)      p(4)      p(3)      p(2)      p(1)      p(0)
+////////////////////////////////////////////////////////////////////////////////
+
+module MulPPGenSgn #(
+	parameter int widthX = 8,  // word width of X
+	parameter int widthY = 8   // word width of Y
+) (
+	input logic [widthX-1:0] X,  // multiplier
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [(widthX+2)*(widthX+widthY)-1:0] PP  // partial products
+);
+
+	localparam int unsigned widthP = widthX + widthY;  // width of single part. prod.
+
+	always_comb begin
+		logic [(widthX+2)*widthP-1:0] ppt;  // partial product vector
+
+		// Initialize ppt to all zeros
+		ppt = '0;
+
+		// Generate partial products x(i)y(k)
+		for (int i = 0; i < widthX-1; i++) begin
+			for (int k = 0; k < widthY-1; k++) begin
+				ppt[i*widthP+i+k] = X[i] & Y[k];
+			end
+			ppt[i*widthP+i+widthY-1] = ~X[i] & Y[widthY-1];
+		end
+
+		for (int k = 0; k < widthY-1; k++) begin
+			ppt[(widthX-1)*widthP+(widthX-1)+k] = X[widthX-1] & ~Y[k];
+		end
+		ppt[(widthX-1)*widthP+(widthX-1)+widthY-1] = X[widthX-1] & Y[widthY-1];
+
+		// Generate correction terms
+		ppt[(widthX+1)*widthP-2] = ~X[widthX-1];
+		ppt[widthX*widthP+widthX-1] = X[widthX-1];
+		ppt[(widthX+2)*widthP-1] = 1'b1;
+		ppt[(widthX+2)*widthP-2] = ~Y[widthY-1];
+		ppt[(widthX+1)*widthP+widthY-1] = Y[widthY-1];
+
+		// Assign output
+		PP = ppt;
+	end
+
+endmodule

--- a/src-flattened/MulPPGenUns.sv
+++ b/src-flattened/MulPPGenUns.sv
@@ -1,0 +1,97 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Partial-product generator for unsigned multiplier (Braun).
+//
+// Partial products for 4x4-bit unsigned multiplication:
+//
+//      0         0         0         0  x(0)y(3)  x(0)y(2)  x(0)y(1)  x(0)y(0)
+//      0         0         0  x(1)y(3)  x(1)y(2)  x(1)y(1)  x(1)y(0)         0
+//      0         0  x(2)y(3)  x(2)y(2)  x(2)y(1)  x(2)y(0)         0         0
+//      0  x(3)y(3)  x(3)y(2)  x(3)y(1)  x(3)y(0)         0         0         0
+////////////////////////////////////////////////////////////////////////////////
+//   p(7)      p(6)      p(5)      p(4)      p(3)      p(2)      p(1)      p(0)
+////////////////////////////////////////////////////////////////////////////////
+
+module MulPPGenUns #(
+	parameter widthX = 8,  // word width of X
+	parameter widthY = 8
+)  // word width of Y
+(
+	input logic [widthX-1:0] X,  // multiplier
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX*(widthX+widthY)-1:0] PP
+);
+
+	// width of single part. prod.
+	localparam widthP = widthX + widthY;
+
+	logic [widthX*widthP-1:0] ppt;  // partial products
+
+	always_comb begin : ppGen
+		ppt = '0;  // partial products
+
+		// partial products x(i)y(k)
+		for (int i = 0; i < widthX; i++) begin
+			for (int k = 0; k < widthY; k++) begin
+				ppt[i*widthP+i+k] = X[i] & Y[k];
+			end
+		end
+
+		PP = ppt;
+	end
+
+endmodule

--- a/src-flattened/MulSgn.sv
+++ b/src-flattened/MulSgn.sv
@@ -1,0 +1,450 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Multiplier for signed numbers (Baugh-Wooley) using carry-save adder and
+// final adder.
+
+module MulSgn #(
+	parameter int widthX = 8,  // word width of X (X <= Y)
+	parameter int widthY = 8,  // word width of Y
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [widthX-1:0] X,  // multiplier
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX+widthY-1:0] P  // product
+);
+
+	logic [(widthX+2)*(widthX+widthY)-1:0] PP;  // partial products
+	logic [widthX+widthY-1:0] ST, CT;  // intermediate sum/carry bits
+
+	// Generation of partial products
+	MulPPGenSgn #(
+		.widthX(widthX),
+		.widthY(widthY)
+	) ppGen (
+		.X (X),
+		.Y (Y),
+		.PP(PP)
+	);
+
+	// Carry-save addition of partial products
+	AddMopCsv #(
+		.width(widthX+widthY),
+		.depth(widthX+2),
+		.speed (speed)
+	) csvAdd (
+		.A(PP),
+		.S(ST),
+		.C(CT)
+	);
+
+	// Final carry-propagate addition
+	Add #(
+		.width(widthX + widthY),
+		.speed(speed)
+	) cpAdd (
+		.A(ST),
+		.B(CT),
+		.S(P)
+	);
+
+endmodule
+
+
+
+module behavioural_MulSgn #(
+	parameter int widthX = 8,  // word width of X (X <= Y)
+	parameter int widthY = 8,  // word width of Y
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [widthX-1:0] X,  // multiplier
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX+widthY-1:0] P  // product
+);
+	assign P = signed'(X) * signed'(Y);
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module Add #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	// Function: Binary adder using parallel-prefix carry-lookahead logic.
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// Internal signals for unsigned operands
+	logic [width-1:0] Auns, Buns, Suns;
+
+	// default ripple-carry adder as slow implementation
+	if (speed == lau_pkg::SLOW) begin
+		// type conversion: std_logic_vector -> unsigned
+		assign Auns = A;
+		assign Buns = B;
+
+		// addition
+		assign Suns = Auns + Buns;
+
+		// type conversion: unsigned -> std_logic_vector
+		assign S = Suns;
+	end else begin
+		// parallel-prefix adders as medium and fast implementations
+
+		// calculate prefix input generate/propagate signals
+		assign GI = A & B;
+		assign PI = A | B;
+		// calculate adder propagate signals (PT = A xor B)
+		assign PT = ~GI & PI;
+
+		// calculate prefix output generate/propagate signals
+		PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+		) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GO),
+			.PO(PO)
+		);
+
+		// calculate sum bits
+		assign S = PT ^ {GO[width-2:0], 1'b0};
+	end
+endmodule
+
+module MulPPGenSgn #(
+	parameter int widthX = 8,  // word width of X
+	parameter int widthY = 8   // word width of Y
+) (
+	input logic [widthX-1:0] X,  // multiplier
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [(widthX+2)*(widthX+widthY)-1:0] PP  // partial products
+);
+
+	localparam int unsigned widthP = widthX + widthY;  // width of single part. prod.
+
+	always_comb begin
+		logic [(widthX+2)*widthP-1:0] ppt;  // partial product vector
+
+		// Initialize ppt to all zeros
+		ppt = '0;
+
+		// Generate partial products x(i)y(k)
+		for (int i = 0; i < widthX-1; i++) begin
+			for (int k = 0; k < widthY-1; k++) begin
+				ppt[i*widthP+i+k] = X[i] & Y[k];
+			end
+			ppt[i*widthP+i+widthY-1] = ~X[i] & Y[widthY-1];
+		end
+
+		for (int k = 0; k < widthY-1; k++) begin
+			ppt[(widthX-1)*widthP+(widthX-1)+k] = X[widthX-1] & ~Y[k];
+		end
+		ppt[(widthX-1)*widthP+(widthX-1)+widthY-1] = X[widthX-1] & Y[widthY-1];
+
+		// Generate correction terms
+		ppt[(widthX+1)*widthP-2] = ~X[widthX-1];
+		ppt[widthX*widthP+widthX-1] = X[widthX-1];
+		ppt[(widthX+2)*widthP-1] = 1'b1;
+		ppt[(widthX+2)*widthP-2] = ~Y[widthY-1];
+		ppt[(widthX+1)*widthP+widthY-1] = Y[widthY-1];
+
+		// Assign output
+		PP = ppt;
+	end
+
+endmodule
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule

--- a/src-flattened/MulUns.sv
+++ b/src-flattened/MulUns.sv
@@ -1,0 +1,438 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Multiplier for unsigned numbers (Brown) using carry-save adder and
+// final adder.
+// P = X*Y
+
+module MulUns #(
+	parameter int widthX = 16,  // word width of X (X <= Y)
+	parameter int widthY = 16,  // word width of Y
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [widthX-1:0] X,  // multiplier
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX+widthY-1:0] P  // product
+);
+
+	logic [widthX*(widthX+widthY)-1:0] PP;  // partial products
+	logic [widthX+widthY-1:0] ST, CT;  // intermediate sum/carry bits
+
+	// Generation of partial products
+	MulPPGenUns #(
+		.widthX(widthX),
+		.widthY(widthY)
+	) ppGen (
+		.X (X),
+		.Y (Y),
+		.PP(PP)
+	);
+
+	// Carry-save addition of partial products
+	AddMopCsv #(
+		.width(widthX+widthY),
+		.depth(widthX),
+		.speed (speed)
+	) csvAdd (
+		.A(PP),
+		.S(ST),
+		.C(CT)
+	);
+
+	// Final carry-propagate addition
+	Add #(
+		.width(widthX+widthY),
+		.speed(speed)
+	) cpAdd (
+		.A(ST),
+		.B(CT),
+		.S(P)
+	);
+
+endmodule
+
+
+
+module behavioural_MulUns #(
+	parameter int widthX = 16,  // word width of X (X <= Y)
+	parameter int widthY = 16,  // word width of Y
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [widthX-1:0] X,  // multiplier
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX+widthY-1:0] P  // product
+);
+	assign P = unsigned'(X) * unsigned'(Y);
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module Add #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	// Function: Binary adder using parallel-prefix carry-lookahead logic.
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// Internal signals for unsigned operands
+	logic [width-1:0] Auns, Buns, Suns;
+
+	// default ripple-carry adder as slow implementation
+	if (speed == lau_pkg::SLOW) begin
+		// type conversion: std_logic_vector -> unsigned
+		assign Auns = A;
+		assign Buns = B;
+
+		// addition
+		assign Suns = Auns + Buns;
+
+		// type conversion: unsigned -> std_logic_vector
+		assign S = Suns;
+	end else begin
+		// parallel-prefix adders as medium and fast implementations
+
+		// calculate prefix input generate/propagate signals
+		assign GI = A & B;
+		assign PI = A | B;
+		// calculate adder propagate signals (PT = A xor B)
+		assign PT = ~GI & PI;
+
+		// calculate prefix output generate/propagate signals
+		PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+		) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GO),
+			.PO(PO)
+		);
+
+		// calculate sum bits
+		assign S = PT ^ {GO[width-2:0], 1'b0};
+	end
+endmodule
+
+module MulPPGenUns #(
+	parameter widthX = 8,  // word width of X
+	parameter widthY = 8
+)  // word width of Y
+(
+	input logic [widthX-1:0] X,  // multiplier
+	input logic [widthY-1:0] Y,  // multiplicand
+	output logic [widthX*(widthX+widthY)-1:0] PP
+);
+
+	// width of single part. prod.
+	localparam widthP = widthX + widthY;
+
+	logic [widthX*widthP-1:0] ppt;  // partial products
+
+	always_comb begin : ppGen
+		ppt = '0;  // partial products
+
+		// partial products x(i)y(k)
+		for (int i = 0; i < widthX; i++) begin
+			for (int k = 0; k < widthY; k++) begin
+				ppt[i*widthP+i+k] = X[i] & Y[k];
+			end
+		end
+
+		PP = ppt;
+	end
+
+endmodule
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule

--- a/src-flattened/Neg.sv
+++ b/src-flattened/Neg.sv
@@ -1,0 +1,191 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// 2's complementer using parallel-prefix propagate-lookahead logic.
+// Z = -A
+
+module Neg #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // result
+);
+
+	logic [width-1:0] AI;  // A inverted
+	logic [width-1:0] PO;  // prefix propagate out
+
+	// Invert A for complement
+	assign AI = ~A;
+
+	// Calculate prefix output propagate signal
+	PrefixAnd #(
+		.width(width),
+		.speed(speed)
+	) prefix (
+		.PI(AI),
+		.PO(PO)
+	);
+
+	// Calculate result bits
+	assign Z = AI ^ {PO[width-2:0], 1'b1};
+
+endmodule
+
+
+
+module behavioural_Neg #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operand
+	output logic [width-1:0] Z   // result
+);
+	assign Z = -A;
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/NegC.sv
+++ b/src-flattened/NegC.sv
@@ -1,0 +1,194 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Conditional 2's complementer using parallel-prefix propagate-lookahead
+// logic.
+// Z = Neg ? -A : A
+
+module NegC #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operand
+	input  logic             Neg,  // negation enable
+	output logic [width-1:0] Z     // result
+);
+
+	logic [width:0] AI;  // A inverted
+	logic [width:0] PO;  // prefix propagate out
+
+	// invert A for complement and attach carry-in
+	assign AI = {A ^ {width{Neg}}, Neg};
+
+	// calculate prefix output propagate signal
+	PrefixAnd #(
+		.width(width + 1),
+		.speed(speed)
+	) prefix (
+		.PI(AI),
+		.PO(PO)
+	);
+
+	// calculate result bits
+	assign Z = AI[width:1] ^ PO[width-1:0];
+
+endmodule
+
+
+
+module behavioural_NegC #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,    // operand
+	input  logic             Neg,  // negation enable
+	output logic [width-1:0] Z     // result
+);
+	assign Z = Neg? -A : A;
+endmodule
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/PrefixAnd.sv
+++ b/src-flattened/PrefixAnd.sv
@@ -1,0 +1,153 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Prefix structures of different depth (i.e. speed) for propagate calculation
+// in different arithmetic units. Compute in m levels new propagate signal
+// pairs for always larger groups of bits. Basic logic operation: AND for
+// propagate signals.
+
+module PrefixAnd #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**(l-1); i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k*2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+					if ((k * 2**l + 2**(l-1) +i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+								PT[(l-1)*n + k*2**l + 2**(l-1) + i] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end : bits
+			end : groups
+		end : levels
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end // fastPrefix
+
+	// Brent-Kung parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*width-1:0] PT;
+
+		assign PT[n-1:0] = PI;
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** l - 1; i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*width+k*2**l+i] = PT[(l-1)*width+k*2**l+i];
+					end
+				end : bits
+				if ((k * 2 ** l + 2 ** l - 1) < n) begin : black
+					assign PT[l*width + k*2**l + 2**l - 1] =
+		PT[(l-1)*width + k*2**l + 2**l - 1] & PT[(l-1)*width + k*2**l + 2**(l-1) - 1];
+				end
+			end : groups
+		end : levels1
+		for (genvar l = m + 1; l <= 2 * m - 1; l++) begin : levels2
+			for (genvar i = 0; i < 2 ** (2 * m - l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*width+i] = PT[(l-1)*width+i];
+				end
+			end : bits
+			for (genvar k = 1; k < 2 ** (l - m); k++) begin : groups
+				if (l < 2 * m - 1) begin : empty
+					for (genvar i = 0; i < 2 ** (2 * m - l - 1) - 1; i++) begin : bits
+						if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+							assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+						end
+					end : bits
+				end
+				if ((k * 2 ** (2 * m - l) + 2 ** (2 * m - l - 1) - 1) < n) begin : black
+					assign PT[l*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] =
+									PT[(l-1)*width + k*2**(2*m-l) + 2**(2*m-l-1) - 1] 
+								  & PT[(l-1)*width + k*2**(2*m-l) - 1];
+				end
+				for (genvar i = 2 ** (2 * m - l - 1); i < 2 ** (2 * m - l); i++) begin : bits
+					if ((k * 2 ** (2 * m - l) + i) < n) begin : white
+						assign PT[l*width+k*2**(2*m-l)+i] = PT[(l-1)*width+k*2**(2*m-l)+i];
+					end
+				end : bits
+			end : groups
+		end : levels2
+		assign PO = PT[2*m*width-1 : (2*m-1)*width];
+	end // mediumPrefix
+
+	// Serial-prefix propagate-lookahead structure
+	if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [width-1:0] PT;
+
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign PO = PT;
+	end // slowPrefix  
+
+endmodule

--- a/src-flattened/PrefixAndOr.sv
+++ b/src-flattened/PrefixAndOr.sv
@@ -1,0 +1,181 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Prefix structures of different depth (i.e. speed) for carry calculation
+// in binary adders. Compute in m levels new generate/propagate signal pairs
+// for always larger groups of bits. Generate signals of the last level correspond
+// to carries in binary addition. Basic logic operations: AND-OR for generate
+// signals, AND for propagate signals.
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/PrefixAndOrCendaround.sv
+++ b/src-flattened/PrefixAndOrCendaround.sv
@@ -1,0 +1,213 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Prefix AND-OR structure with
+//   - fast carry-in (CI)
+//   - carry-out (CO) independent of carry-in (for end-around carry adders)
+
+module PrefixAndOrCendaround #(
+	parameter int unsigned width = 8,    // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,
+	input  logic [width-1:0] PI,  // gen./prop. in
+	input  logic             CI,  // carry in
+	output logic [width-1:0] GO,
+	output logic [width-1:0] PO,  // gen./prop. out
+	output logic             CO   // carry out
+);
+
+	logic [width-1:0] GT, PT;  // gen./prop. temp
+
+	// normal prefix calculation
+	PrefixAndOr #(
+		.width(width),
+		.speed(speed)
+	) prefix_inst (
+		.GI(GI),
+		.PI(PI),
+		.GO(GT),
+		.PO(PT)
+	);
+
+	// carry-out
+	assign CO = GT[width-1];
+	// additional prefix calculation level for fast carry-in
+	assign GO = GT | (PT & {{width - 1{CI}}});
+	assign PO = PT;
+
+endmodule
+
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/PrefixAndOrCfast.sv
+++ b/src-flattened/PrefixAndOrCfast.sv
@@ -1,0 +1,212 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Prefix AND-OR structure with
+//   - fast carry-in (CI)
+
+module PrefixAndOrCfast #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,
+	input  logic [width-1:0] PI,  // gen./prop. in
+	input  logic             CI,  // carry in
+	output logic [width-1:0] GO,
+	output logic [width-1:0] PO  // gen./prop. out
+);
+
+	logic [width-1:0] CIT;  // carry in temp
+	logic [width-1:0] GT, PT;  // gen./prop. temp
+
+	// normal prefix calculation
+	PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+	) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GT),
+			.PO(PT)
+	);
+
+	// additional prefix calculation level for fast carry-in
+	always_comb begin
+		CIT = {width{CI}};
+		GO  = GT | (PT & CIT);
+	end
+
+endmodule
+
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/PrefixOr.sv
+++ b/src-flattened/PrefixOr.sv
@@ -1,0 +1,151 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Prefix structures of different depth (i.e. speed) for propagate calculation
+// in different arithmetic units. Compute in m levels new propagate signal
+// pairs for always larger groups of bits. Basic logic operation: OR for
+// propagate signals.
+
+module PrefixOr #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO   // propagate out
+);
+
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;  // gen./prop. temp
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+					if ((k * 2 ** l + i) < n) begin : white
+						assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+					end
+					if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+			  PT[(l-1)*n + k*2**l + 2**(l-1) + i] |
+			  PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end
+			end
+		end
+		assign PO = PT[(m+1)*n-1 : m*n];
+	end  // Brent-Kung parallel-prefix propagate-lookahead structure
+	else if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] PT;  // gen./prop. temp
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k * 2**l +i) < n) begin : white
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end
+				end // bits
+				if ((k*2**l + 2**l -1) < n) begin : black
+					assign PT[l*n + k*2**l + 2**l -1] =
+									PT[(l-1)*n + k*2**l + 2**l     -1]
+									| PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end
+			end
+		end // level1
+
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k * 2**(2*m -l) + i) < n) begin : white
+							assign PT[l*n + k* 2**(2*m-l) +i] = PT[(l-1)*n + k* 2**(2*m-l) +i];
+						end
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] =
+									PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+								  | PT[(l-1)*n + k* 2**(2*m -l) - 1];
+				end // black
+				for (genvar i = 2**(2*m -l -1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end
+				end // bits
+			end
+		end // level2
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix propagate-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] PT;  // gen./prop. temp
+		assign PT[0] = PI[0];
+
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign PT[i] = PI[i] | PT[i-1];
+		end
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/PrefixXor.sv
+++ b/src-flattened/PrefixXor.sv
@@ -1,0 +1,174 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Prefix structures of different depth (i.e., speed) for propagate calculation
+// in different arithmetic units. Compute in m levels new propagate signal
+// pairs for always larger groups of bits. Basic logic operation: XOR for
+// Gray to binary conversion.
+
+module PrefixXor #(
+	parameter int width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+)  // performance parameter
+(
+	input  logic [width-1:0] PI,  // propagate in
+	output logic [width-1:0] PO
+);  // propagate out
+
+	// prefix structure width and depth
+	localparam n = width;
+	localparam m = $clog2(width);
+
+	// Sklansky parallel-prefix propagate-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] PT;
+
+		// Initialize PT
+		assign PT[n-1:0] = PI;
+
+		// Compute PT levels
+		for (genvar l = 1; l <= m; l++) begin : levels
+			for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+				for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits_white
+					if ((k * 2 ** l + i) < n) begin
+						assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+					end
+				end
+
+				for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits_black
+					if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin
+						assign PT[l*n + k*2**l + 2**(l-1) + i] =
+				PT[(l-1)*n + k*2**l + 2**(l-1) + i] ^ PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+					end
+				end
+			end
+		end
+
+		// Assign output
+		assign PO = PT[(m+1)*n-1 : m*n];
+
+	end  // Brent-Kung parallel-prefix propagate-lookahead structure
+	else if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [2*m*n -1:0] PT;
+
+		// Initialize PT
+		assign PT[n-1:0] = PI;
+
+		// Compute levels1
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k * 2**l + 2**l -1) < n) begin : black
+					assign PT[l*n + k* 2**l + 2**l - 1] =
+								PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							  ^ PT[(l-1)*n + k* 2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+
+		// Compute levels2
+		for (genvar l = m + 1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l-1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end // bits
+				end // empty
+
+				if ((k* 2**(2*m -l) + 2**(2*m -l-1) -1) < n) begin : black
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] =
+								PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1] 
+							  ^ PT[(l-1)*n + k* 2**(2*m-l) -1];
+				end // black
+
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end // bits
+			end
+		end // levels2
+
+		// Assign output
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+
+	end  // Serial-prefix propagate-lookahead structure
+	else begin : slowPrefix
+		logic [n-1:0] PT;
+
+		// Initialize PT
+		assign PT[0] = PI[0];
+		for (genvar i = 1; i < n; i++) begin
+			assign PT[i] = PI[i] ^ PT[i-1];
+		end
+
+		// Assign output
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/RedAnd.sv
+++ b/src-flattened/RedAnd.sv
@@ -1,0 +1,92 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// AND all bits of the input vector.
+// Z = A[0] & A[1] & A[2]... & A[width-1]
+
+module RedAnd #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,  // input vector
+	output logic             Z   // output bit
+);
+
+	logic zv;
+
+	// AND all bits
+	// Using a procedural block for behavioral description
+	always_comb begin
+		zv = A[0];
+		for (int i = 1; i < width; i++) begin
+			zv &= A[i];
+		end
+		Z = zv;
+	end
+
+endmodule
+
+
+
+module behavioural_RedAnd #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,  // input vector
+	output logic             Z   // output bit
+);
+
+	assign Z = &A;
+
+endmodule

--- a/src-flattened/RedOr.sv
+++ b/src-flattened/RedOr.sv
@@ -1,0 +1,92 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// OR all bits of the input vector.
+// Z = A[0] | A[1] | A[2]... | A[width-1]
+
+module RedOr #(
+	parameter int width = 8  // word width
+) (
+	input logic [width-1:0] A,  // input vector
+	output logic Z  // output bit
+);
+
+	logic zv;
+	
+	// OR all bits
+	// behavioral description used (well handled by all synthesizers)
+	always_comb begin
+		zv = A[0];
+		for (int i = 1; i < width; i++) begin
+			zv |= A[i];
+		end
+		Z = zv;
+	end
+
+endmodule
+
+
+
+module behavioural_RedOr #(
+	parameter int width = 8  // word width
+) (
+	input logic [width-1:0] A,  // input vector
+	output logic Z  // output bit
+);
+
+	assign Z = |A;
+
+endmodule

--- a/src-flattened/RedXor.sv
+++ b/src-flattened/RedXor.sv
@@ -1,0 +1,92 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// XOR all bits of the input vector.
+// Z = A[0] ^ A[1] ^ A[2]... ^ A[width-1]
+
+module RedXor #(
+	parameter int width = 8  // word width
+) (
+	input logic [width-1:0] A,  // input vector
+	output logic Z  // output bit
+);
+
+	logic zv;
+
+	// XOR all bits
+	// behavioral description used (well handled by all synthesizers)
+	always_comb begin
+		zv = A[0];
+		for (int i = 1; i < width; i++) begin
+			zv ^= A[i];
+		end
+		Z = zv;
+	end
+
+endmodule
+
+
+
+module behavioural_RedXor #(
+	parameter int width = 8  // word width
+) (
+	input logic [width-1:0] A,  // input vector
+	output logic Z  // output bit
+);
+
+	assign Z = ^A;
+
+endmodule

--- a/src-flattened/Reg.sv
+++ b/src-flattened/Reg.sv
@@ -1,0 +1,77 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Register for pipelining.
+
+module Reg #(
+        parameter int width = 8  // word width
+) (
+        input logic CLK,  // clock
+        input logic RST,  // reset
+        input logic [width-1:0] D,  // data input
+        output logic [width-1:0] Q  // data output
+);
+
+    // purpose: memorizing process to register inputs
+    always_ff @(posedge CLK or negedge RST) begin
+        if (!RST) begin
+            Q <= '0;
+        end else begin
+            Q <= D;
+        end
+    end
+
+endmodule

--- a/src-flattened/SqrPPGenSgn.sv
+++ b/src-flattened/SqrPPGenSgn.sv
@@ -1,0 +1,123 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Partial-product generator for signed squarer.
+//
+// Partial products for 4-bit squaring:
+//
+//  ~x(7) ~x(2)y(3) ~x(1)y(3) ~x(0)y(3)  x(0)y(2)  x(0)y(1)         0  x(0)y(0)
+//      1  x(3)y(3)         0  x(1)y(2)      x(7)  x(1)y(1)         0         0
+//      0         0         0  x(2)y(2)      x(7)         0         0         0
+////////////////////////////////////////////////////////////////////////////////
+//   p(7)      p(6)      p(5)      p(4)      p(3)      p(2)      p(1)      p(0)
+////////////////////////////////////////////////////////////////////////////////
+
+module SqrPPGenSgn #(
+	parameter width = 8
+) (
+	input logic [width-1:0] X,  // operand
+	output logic [(width/2+1)*2*width-1:0] PP  // partial products
+);
+
+	localparam widthP = 2*width;
+	logic [(width/2+1)*widthP-1:0] ppt;  // internal signal
+
+	always_comb begin
+		// Defaults
+		ppt = '0;
+
+		// Lower products x(i)x(k), i != k
+		for (int i = 0; i < (width-1) /2; i++) begin
+			for (int k = i + 1; k < width-i-1; k++) begin
+				ppt[i*widthP +i+k+1] = X[i] & X[k];
+			end
+		end
+
+		// Upper products x(i)x(k), i != k
+		for (int k = 0; k < width-1; k++) begin
+			ppt[width+k] = ~X[k] & X[width-1];
+		end
+		for (int i = 1; i < width/2; i++) begin
+			for (int k = i; k < width -i-1; k++) begin
+				ppt[i*widthP+width-i+k] = X[k] & X[width-i-1];
+			end
+		end
+
+		// Lower products x(i)x(i)
+		for (int i = 0; i <= (width-1) /2; i++) begin
+			ppt[i*widthP+2*i] = X[i];
+		end
+
+		// Upper products x(i)x(i)
+		for (int i = 1; i <= width/2; i++) begin
+			ppt[i*widthP+2*width-2*i] = X[width-i];
+		end
+
+		// Correction terms
+		ppt[widthP-1]   = ~X[width-1];
+		ppt[2*widthP-1] = 1'b1;
+		if (width % 2 == 0) begin
+			ppt[(width/2-1)*widthP+width-1] = X[width-1];
+			ppt[(width/2)*widthP+width-1]   = X[width-1];
+		end else begin
+			ppt[(width/2)*widthP+width] = X[width-1];
+		end
+
+		// Assign to output
+		PP = ppt;
+	end
+
+endmodule

--- a/src-flattened/SqrPPGenUns.sv
+++ b/src-flattened/SqrPPGenUns.sv
@@ -1,0 +1,110 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Partial-product generator for unsigned squarer.
+//
+// Partial products for 4-bit squaring:
+//
+//      0  x(2)y(3)  x(1)y(3)  x(0)y(3)  x(0)y(2)  x(0)y(1)         0  x(0)y(0)
+//      0  x(3)y(3)         0  x(1)y(2)         0  x(1)y(1)         0         0
+//      0         0         0  x(2)y(2)         0         0         0         0
+////////////////////////////////////////////////////////////////////////////////
+//   p(7)      p(6)      p(5)      p(4)      p(3)      p(2)      p(1)      p(0)
+////////////////////////////////////////////////////////////////////////////////
+
+module SqrPPGenUns #(
+	parameter width = 8
+) (
+	input logic [width-1:0] X,  // operand
+	output logic [(width/2+1)*2*width-1:0] PP  // partial products
+);
+
+	localparam widthP = 2*width;
+	logic [(width/2+1)*widthP-1:0] ppt;  // internal signal
+
+	always_comb begin
+		// Defaults
+		ppt = '0;
+
+		// Lower products x(i)x(k), i != k
+		for (int i = 0; i < (width-1)/2; i++) begin
+			for (int k = i + 1; k < width -i-1; k++) begin
+				ppt[i*widthP+i+k+1] = X[i] & X[k];
+			end
+		end
+
+		// Upper products x(i)x(k), i != k
+		for (int i = 0; i < width/2; i++) begin
+			for (int k = i; k < width -i-1; k++) begin
+				ppt[i*widthP+width-i+k] = X[k] & X[width-i-1];
+			end
+		end
+
+		// Lower products x(i)x(i)
+		for (int i = 0; i <= (width-1)/2; i++) begin
+			ppt[i*widthP+2*i] = X[i];
+		end
+
+		// Upper products x(i)x(i)
+		for (int i = 1; i <= width/2; i++) begin
+			ppt[i*widthP+2*width-2*i] = X[width-i];
+		end
+
+		// Assign to output
+		PP = ppt;
+	end
+
+endmodule

--- a/src-flattened/SqrSgn.sv
+++ b/src-flattened/SqrSgn.sv
@@ -1,0 +1,450 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Squarer for signed numbers using optimized partial-product generation,
+// carry-save adder and final adder.
+// P = X*X
+
+module SqrSgn #(
+	parameter width = 8,
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [  width-1:0] X,  // operand
+	output logic [2*width-1:0] P   // product
+);
+
+	logic [(width/2+1)*2*width-1:0] PP;  // partial products
+	logic [2*width-1:0] ST, CT;  // intermediate sum/carry bits
+
+	// Generation of partial products
+	SqrPPGenSgn #(width) ppGen (
+		.X (X),
+		.PP(PP)
+	);
+
+	// Carry-save addition of partial products
+	AddMopCsv #(2*width, width/2 +1, speed) csvAdd (
+		.A(PP),
+		.S(ST),
+		.C(CT)
+	);
+
+	// Final carry-propagate addition
+	Add #(2*width, speed) cpAdd (
+		.A(ST),
+		.B(CT),
+		.S(P)
+	);
+
+endmodule
+
+
+
+module behavioural_SqrSgn #(
+	parameter width = 8,
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [  width-1:0] X,  // operand
+	output logic [2*width-1:0] P   // product
+);
+	assign P = signed'(X) * signed'(X);
+endmodule
+
+module SqrPPGenSgn #(
+	parameter width = 8
+) (
+	input logic [width-1:0] X,  // operand
+	output logic [(width/2+1)*2*width-1:0] PP  // partial products
+);
+
+	localparam widthP = 2*width;
+	logic [(width/2+1)*widthP-1:0] ppt;  // internal signal
+
+	always_comb begin
+		// Defaults
+		ppt = '0;
+
+		// Lower products x(i)x(k), i != k
+		for (int i = 0; i < (width-1) /2; i++) begin
+			for (int k = i + 1; k < width-i-1; k++) begin
+				ppt[i*widthP +i+k+1] = X[i] & X[k];
+			end
+		end
+
+		// Upper products x(i)x(k), i != k
+		for (int k = 0; k < width-1; k++) begin
+			ppt[width+k] = ~X[k] & X[width-1];
+		end
+		for (int i = 1; i < width/2; i++) begin
+			for (int k = i; k < width -i-1; k++) begin
+				ppt[i*widthP+width-i+k] = X[k] & X[width-i-1];
+			end
+		end
+
+		// Lower products x(i)x(i)
+		for (int i = 0; i <= (width-1) /2; i++) begin
+			ppt[i*widthP+2*i] = X[i];
+		end
+
+		// Upper products x(i)x(i)
+		for (int i = 1; i <= width/2; i++) begin
+			ppt[i*widthP+2*width-2*i] = X[width-i];
+		end
+
+		// Correction terms
+		ppt[widthP-1]   = ~X[width-1];
+		ppt[2*widthP-1] = 1'b1;
+		if (width % 2 == 0) begin
+			ppt[(width/2-1)*widthP+width-1] = X[width-1];
+			ppt[(width/2)*widthP+width-1]   = X[width-1];
+		end else begin
+			ppt[(width/2)*widthP+width] = X[width-1];
+		end
+
+		// Assign to output
+		PP = ppt;
+	end
+
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module Add #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	// Function: Binary adder using parallel-prefix carry-lookahead logic.
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// Internal signals for unsigned operands
+	logic [width-1:0] Auns, Buns, Suns;
+
+	// default ripple-carry adder as slow implementation
+	if (speed == lau_pkg::SLOW) begin
+		// type conversion: std_logic_vector -> unsigned
+		assign Auns = A;
+		assign Buns = B;
+
+		// addition
+		assign Suns = Auns + Buns;
+
+		// type conversion: unsigned -> std_logic_vector
+		assign S = Suns;
+	end else begin
+		// parallel-prefix adders as medium and fast implementations
+
+		// calculate prefix input generate/propagate signals
+		assign GI = A & B;
+		assign PI = A | B;
+		// calculate adder propagate signals (PT = A xor B)
+		assign PT = ~GI & PI;
+
+		// calculate prefix output generate/propagate signals
+		PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+		) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GO),
+			.PO(PO)
+		);
+
+		// calculate sum bits
+		assign S = PT ^ {GO[width-2:0], 1'b0};
+	end
+endmodule
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule

--- a/src-flattened/SqrUns.sv
+++ b/src-flattened/SqrUns.sv
@@ -1,0 +1,438 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Squarer for unsigned numbers using optimized partial-product generation,
+// carry-save adder and final adder.
+// P = X^2
+
+module SqrUns #(
+	parameter width = 8,
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [  width-1:0] X,  // operand
+	output logic [2*width-1:0] P   // product
+);
+
+	// Signals
+	logic [((width/2 + 1) * 2 * width) - 1:0] PP;  // Partial products
+	logic [2 * width - 1:0] ST, CT;  // Intermediate sum/carry bits
+
+	// Generation of partial products
+	SqrPPGenUns #(width) ppGen (
+		.X (X),
+		.PP(PP)
+	);
+
+	// Carry-save addition of partial products
+	AddMopCsv #(2 * width, width / 2 + 1, speed) csvAdd (
+		.A(PP),
+		.S(ST),
+		.C(CT)
+	);
+
+	// Final carry-propagate addition
+	Add #(2 * width, speed) cpAdd (
+		.A(ST),
+		.B(CT),
+		.S(P)
+	);
+
+endmodule
+
+
+
+module behavioural_SqrUns #(
+	parameter width = 8,
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [  width-1:0] X,  // operand
+	output logic [2*width-1:0] P   // product
+);
+	assign P = X**2;
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule
+
+module Add #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A,  // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S   // sum
+);
+
+	// Function: Binary adder using parallel-prefix carry-lookahead logic.
+
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// Internal signals for unsigned operands
+	logic [width-1:0] Auns, Buns, Suns;
+
+	// default ripple-carry adder as slow implementation
+	if (speed == lau_pkg::SLOW) begin
+		// type conversion: std_logic_vector -> unsigned
+		assign Auns = A;
+		assign Buns = B;
+
+		// addition
+		assign Suns = Auns + Buns;
+
+		// type conversion: unsigned -> std_logic_vector
+		assign S = Suns;
+	end else begin
+		// parallel-prefix adders as medium and fast implementations
+
+		// calculate prefix input generate/propagate signals
+		assign GI = A & B;
+		assign PI = A | B;
+		// calculate adder propagate signals (PT = A xor B)
+		assign PT = ~GI & PI;
+
+		// calculate prefix output generate/propagate signals
+		PrefixAndOr #(
+			.width(width),
+			.speed(speed)
+		) prefix (
+			.GI(GI),
+			.PI(PI),
+			.GO(GO),
+			.PO(PO)
+		);
+
+		// calculate sum bits
+		assign S = PT ^ {GO[width-2:0], 1'b0};
+	end
+endmodule
+
+module SqrPPGenUns #(
+	parameter width = 8
+) (
+	input logic [width-1:0] X,  // operand
+	output logic [(width/2+1)*2*width-1:0] PP  // partial products
+);
+
+	localparam widthP = 2*width;
+	logic [(width/2+1)*widthP-1:0] ppt;  // internal signal
+
+	always_comb begin
+		// Defaults
+		ppt = '0;
+
+		// Lower products x(i)x(k), i != k
+		for (int i = 0; i < (width-1)/2; i++) begin
+			for (int k = i + 1; k < width -i-1; k++) begin
+				ppt[i*widthP+i+k+1] = X[i] & X[k];
+			end
+		end
+
+		// Upper products x(i)x(k), i != k
+		for (int i = 0; i < width/2; i++) begin
+			for (int k = i; k < width -i-1; k++) begin
+				ppt[i*widthP+width-i+k] = X[k] & X[width-i-1];
+			end
+		end
+
+		// Lower products x(i)x(i)
+		for (int i = 0; i <= (width-1)/2; i++) begin
+			ppt[i*widthP+2*i] = X[i];
+		end
+
+		// Upper products x(i)x(i)
+		for (int i = 1; i <= width/2; i++) begin
+			ppt[i*widthP+2*width-2*i] = X[width-i];
+		end
+
+		// Assign to output
+		PP = ppt;
+	end
+
+endmodule
+
+module Cpr #(
+	parameter int              depth = 4,             // number of input bits
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [depth-1:0] A,   // input bits
+	input  logic [depth-4:0] CI,  // intermediate carries in
+	output logic             S,   // sum out
+	output logic             C,   // carry out
+	output logic [depth-4:0] CO   // intermediate carries out
+);
+
+	logic [depth+2*(depth-2)-1:0] F;  // FIFO vector of internal signals
+	logic [            depth-3:0] CIT, COT;  // temp. int. carries
+
+	// put input bits to beginning of FIFO vector
+	assign F[depth-1:0] = A;
+
+	// temporary intermediate carries in
+	assign CIT[depth-3:0] = {1'b0, CI[depth-4:0]};
+
+	// compressor with linear structure
+	if (speed == lau_pkg::SLOW) begin : slowCpr
+		// first full-adder
+		FullAdder fa0 (
+			.A (F[0]),
+			.B (F[1]),
+			.CI(F[2]),
+			.S (F[depth]),
+			.CO(COT[0])
+		);
+
+		// linear arrangement of full-adders
+		for (genvar i = 1; i < depth-2; i++) begin : linear
+			FullAdder fa (
+				.A (F[i+2]),
+				.B (CIT[i-1]),
+				.CI(F[depth+(i-1)*2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+		end
+	end  // compressor with tree structure
+	else begin : fastCpr
+		// tree arrangement of full-adders
+
+		for (genvar i = 0; i < depth-2; i++) begin : tree
+			// take inputs from beginning of FIFO vector
+			// attach sum output to end of FIFO vector
+			// put carry output to intermediate carry-out
+			FullAdder fa (
+				.A (F[i*3]),
+				.B (F[i*3+1]),
+				.CI(F[i*3+2]),
+				.S (F[depth+i*2]),
+				.CO(COT[i])
+			);
+			// attach intermediate carry-in to end of FIFO vector
+			assign F[depth+i*2+1] = CIT[i];
+		end
+	end
+
+	// intermediate carries out
+	assign CO = COT[depth-4:0];
+
+	// sum and carry out
+	assign S  = F[3*depth-6];
+	assign C  = COT[depth-3];
+
+endmodule
+
+module AddMopCsv #(
+	parameter int              width = 8,             // word width
+	parameter int              depth = 4,             // number of operands
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [(depth*width)-1:0] A,  // operands
+	output logic [        width-1:0] S,  // sum
+	output logic [        width-1:0] C   // carry vector
+);
+
+	logic [      (depth*width)-1:0] AT;  // re-arranged inputs
+	logic [(depth-3)*(width+1)-1:0] CI;  // intermediate carries
+	logic [              width-1:0] CT;  // unshifted output carries
+
+	// re-arrange input bits: group bits of same magnitude
+	always_comb begin : swizzle
+		for (int k = 0; k < depth; k++) begin
+			for (int i = 0; i < width; i++) begin
+				AT[i*depth+k] = A[k*width+i];
+			end
+		end
+	end
+
+	// set intermediate carries into first slice
+	assign CI[depth-4:0] = 1'b0;
+
+	// carry-save addition using (m,2) compressor bit-slices
+	for (genvar i = 0; i < width; i++) begin : bits
+		Cpr #(
+			.depth(depth),
+			.speed(speed)
+		) slice (
+			.A (AT[(i+1)*depth -1 : i*depth]),
+			.CI(CI[(i+1)*(depth-3) -1 : i*(depth-3)]),
+			.S (S[i]),
+			.C (CT[i]),
+			.CO(CI[(i+2)*(depth-3) -1 : (i+1)*(depth-3)])
+		);
+	end
+
+	// shift left output carries by one position
+	assign C = {CT[width-2:0], 1'b0};
+
+endmodule

--- a/src-flattened/SqrtArrUns.sv
+++ b/src-flattened/SqrtArrUns.sv
@@ -1,0 +1,147 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Restoring array square-root extractor for unsigned numbers.
+// Q = floor(sqrt(X))
+// R = X - Q^2
+
+module SqrtArrUns #(
+	parameter int widthX = 8
+) (
+	input  logic [widthX-1:0] X,  // operand
+	output logic [(widthX+1)/2-1:0] Q,  // square root
+	output logic [(widthX+1)/2-1:0] R  // remainder
+);
+
+	// Word width of Q
+	localparam widthQ = (widthX + 1) / 2;
+
+	// Signals
+	logic [widthX:0] XT;  // Extended operand
+	logic [widthQ-1:0] QT;  // Temp quotient
+	logic [widthQ*(widthQ+2)-1:0] QTI;  // Quotients
+	logic [widthQ*(widthQ+2)-1:0] ST;  // Sums
+	logic [(widthQ+1)*(widthQ+3)-1:0] RT;  // Remainders
+	logic [widthQ*(widthQ+3)-1:0] CT;  // Carries
+
+	// Extend operand X
+	assign XT = {1'b0, X};
+
+	// first partial remainder is operand X
+	assign RT[widthQ*(widthQ+3)+1+:widthQ+1] = {1'b0, XT[widthQ+:widthQ]};
+
+	// Process one row for each quotient bit
+	for (genvar k = 0; k < widthQ; k++) begin : row
+
+		// Carry-in = '1' for subtraction
+		assign CT[k*(widthQ+3)] = 1'b1;
+		// Attach next operand bit to current remainder
+		assign RT[(k+1)*(widthQ+3)] = XT[k];
+
+		logic [widthQ+1:0] qtv;
+		always_comb begin : partQuot
+			qtv[     k  :0  ] = '0;
+			qtv[     k+1:k  ] = 2'b01;
+			qtv[widthQ+1:k+2] = QT >> (k+1); // QT[widthQ-1 : k+1]
+
+			QTI[k*(widthQ+2) +: widthQ+2] = ~qtv; 
+		end
+
+		// Form current partial quotient (inverted)
+		for (genvar i = 0; i < widthQ+2; i++) begin : bits
+			// Perform subtraction using ripple-carry adder
+			// (partial remainder - partial quotient)
+			FullAdder fa (
+				.A (QTI[  k   * (widthQ+2) +i  ]),
+				.B (RT [(k+1) * (widthQ+3) +i  ]),
+				.CI(CT [  k   * (widthQ+3) +i  ]),
+				.S (ST [  k   * (widthQ+2) +i  ]),
+				.CO(CT [  k   * (widthQ+3) +i+1])
+			);
+		end
+
+		always_comb begin
+		   // If subtraction result is negative => quotient bit = '0'
+			QT[k] = CT[k*(widthQ+3)+widthQ+2];
+
+			// Restore previous partial remainder if quotient bit = '0'
+			if (QT[k] == 1'b0) begin
+				RT[k*(widthQ+3)+1+:widthQ+2] = RT[(k+1)*(widthQ+3)+:widthQ+2];
+			end else begin
+				RT[k*(widthQ+3)+1+:widthQ+2] = ST[k*(widthQ+2)+:widthQ+2];
+			end 
+		end
+	end
+
+
+	// Last partial remainder is division remainder
+	assign Q = QT;
+	assign R = RT[widthQ:1];
+
+endmodule
+
+
+
+module behavioural_SqrtArrUns #(
+	parameter int widthX = 8
+) (
+	input  logic [widthX-1:0] X,  // operand
+	output logic [(widthX+1)/2-1:0] Q,  // square root
+	output logic [(widthX+1)/2-1:0] R  // remainder
+);
+	assign Q = $floor($sqrt(X));
+	assign R = X - Q**2;
+endmodule

--- a/src-flattened/Sub.sv
+++ b/src-flattened/Sub.sv
@@ -1,0 +1,237 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary subtractor using parallel-prefix carry-lookahead logic.
+// S = A-B
+
+module Sub #(
+	parameter width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A, // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S  // sum
+);
+
+	logic [width-1:0] BI;  // B inverted
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// invert B for subtraction
+	assign BI = ~B;
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = A[0] | BI[0];
+	assign PI[0] = 1'b0;
+	// calculate adder propagate signal (0) (PT = A xor B)
+	assign PT[0] = A[0] ^ BI[0];
+	// calculate prefix input generate/propagate signals (1 to width-1)
+	for (genvar i = 1; i < width; i++) begin : preproc
+		assign GI[i] = A[i] & BI[i];
+		assign PI[i] = A[i] | BI[i];
+		// calculate adder propagate signal (1 to width-1) (PT = A xor B)
+		assign PT[i] = ~GI[i] & PI[i];
+	end
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(
+		.width(width),
+		.speed(speed)
+	) prefix_inst (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// calculate sum bits
+	assign S = PT ^ {GO[width-2:0], 1'b1};
+
+endmodule
+
+
+
+module behavioural_Sub #(
+	parameter width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] A, // operands
+	input  logic [width-1:0] B,
+	output logic [width-1:0] S  // sum
+);
+	assign S = A - B;
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/SubC.sv
+++ b/src-flattened/SubC.sv
@@ -1,0 +1,248 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary subtractor using parallel-prefix carry-lookahead logic with:
+//   - carry-in (CI), subtracted
+//   - carry-out (CO), '1' if subtraction result is negative
+// {CO,S} = A - B -CI
+
+module SubC #(
+	parameter width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [width-1:0] A,  // operands
+	input logic [width-1:0] B,
+	input logic CI,  // carry in (subtracted)
+	output logic [width-1:0] S,  // sum
+	output logic CO // carry out ('1' if S negative)
+);
+
+	logic [width-1:0] BI;  // B inverted
+	logic CII;  // CI inverted
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// invert B and CI for subtraction
+	assign BI = ~B;
+	assign CII = ~CI;
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = (A[0] & BI[0]) | (A[0] & CII) | (BI[0] & CII);
+	assign PI[0] = 1'b0;
+	// calculate adder propagate signal (0) (PT = A xor B)
+	assign PT[0] = A[0] ^ BI[0];
+	// calculate prefix input generate/propagate signals (1 to width-1)
+	generate
+		for (genvar i = 1; i < width; i++) begin : preproc
+			assign GI[i] = A[i] & BI[i];
+			assign PI[i] = A[i] | BI[i];
+			// calculate adder propagate signal (1 to width-1) (PT = A xor B)
+			assign PT[i] = ~GI[i] & PI[i];
+		end
+	endgenerate
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(
+		.width(width),
+		.speed(speed)
+	) prefix_inst (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// calculate sum and carry-out bits
+	assign S  = PT ^ {GO[width-2:0], CII};
+	assign CO = ~GO[width-1];
+
+endmodule
+
+
+
+module behavioural_SubC #(
+	parameter width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [width-1:0] A,  // operands
+	input logic [width-1:0] B,
+	input logic CI,  // carry in (subtracted)
+	output logic [width-1:0] S,  // sum
+	output logic CO // carry out ('1' if S negative)
+);
+	assign {CO,S} = A - B -CI;
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/SubCZ.sv
+++ b/src-flattened/SubCZ.sv
@@ -1,0 +1,256 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary subtractor using parallel-prefix carry-lookahead logic with:
+//   - carry-in (CI), subtracted
+//   - carry-out (CO), '1' if subtraction result is negative
+//   - zero flag (only valid for CI = 0)
+// {CO,S} = A - B -CI
+// Z = (S==0)
+
+module SubCZ #(
+	parameter width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [width-1:0] A,  // operands
+	input logic [width-1:0] B,
+	input logic CI,  // carry in (subtracted)
+	output logic [width-1:0] S,  // sum
+	output logic CO,  // carry out ('1' if S negative)
+	output logic Z // zero flag (only valid for CI = 0)
+);
+
+	logic [width-1:0] BI;  // B inverted
+	logic CII;  // CI inverted
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// invert B and CI for subtraction
+	assign BI = ~B;
+	assign CII = ~CI;
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = (A[0] & BI[0]) | (A[0] & CII) | (BI[0] & CII);
+	assign PI[0] = A[0] ^ BI[0];
+	// calculate adder propagate signal (0) (PT = A xor B)
+	assign PT[0] = PI[0];
+	// calculate prefix input generate/propagate signals (1 to width-1)
+	generate
+		for (genvar i = 1; i < width; i++) begin : preproc
+			assign GI[i] = A[i] & BI[i];
+			assign PI[i] = A[i] ^ BI[i];
+			// calculate adder propagate signal (1 to width-1) (PT = A xor B)
+			assign PT[i] = PI[i];
+		end
+	endgenerate
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(
+		.width(width),
+		.speed(speed)
+	) prefix_inst (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// calculate sum bits, carry-out bits, and zero flag
+	assign S  = PT ^ {GO[width-2:0], CII};
+	assign CO = ~GO[width-1];
+	assign Z  = PO[width-1];
+
+endmodule
+
+
+
+module behavioural_SubCZ #(
+	parameter width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [width-1:0] A,  // operands
+	input logic [width-1:0] B,
+	input logic CI,  // carry in (subtracted)
+	output logic [width-1:0] S,  // sum
+	output logic CO,  // carry out ('1' if S negative)
+	output logic Z // zero flag (only valid for CI = 0)
+);
+	assign {CO,S} = A - B - CI;
+	// Z is not valid when CI != 0, so set it to X
+	assign Z = CI ? 'x : (S == '0);
+endmodule
+
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/SubV.sv
+++ b/src-flattened/SubV.sv
@@ -1,0 +1,258 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary subtractor using parallel-prefix carry-lookahead logic with:
+//   - carry-in (CI), subtracted
+//   - 2's complement overflow flag (V)
+// S = A -B -CI
+// V = (S>MAX) | (S<MIN)
+
+module SubV #(
+	parameter width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [width-1:0] A,  // operands
+	input logic [width-1:0] B,
+	input logic CI,  // carry in (subtracted)
+	output logic [width-1:0] S,  // sum
+	output logic V // overflow flag
+);
+
+	logic [width-1:0] BI;  // B inverted
+	logic CII;  // CI inverted
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// invert B and CI for subtraction
+	assign BI = ~B;
+	assign CII = ~CI;
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = (A[0] & BI[0]) | (A[0] & CII) | (BI[0] & CII);
+	assign PI[0] = 1'b0;
+	// calculate adder propagate signal (0) (PT = A xor B)
+	assign PT[0] = A[0] ^ BI[0];
+	// calculate prefix input generate/propagate signals (1 to width-1)
+	generate
+		for (genvar i = 1; i < width; i++) begin : preproc
+			assign GI[i] = A[i] & BI[i];
+			assign PI[i] = A[i] | BI[i];
+			// calculate adder propagate signal (1 to width-1) (PT = A xor B)
+			assign PT[i] = ~GI[i] & PI[i];
+		end
+	endgenerate
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(
+		.width(width),
+		.speed(speed)
+	) prefix_inst (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// calculate sum and overflow bits
+	assign S = PT ^ {GO[width-2:0], CII};
+	assign V = GO[width-1] ^ GO[width-2];
+
+endmodule
+
+
+
+module behavioural_SubV #(
+	parameter width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [width-1:0] A,  // operands
+	input logic [width-1:0] B,
+	input logic CI,  // carry in (subtracted)
+	output logic [width-1:0] S,  // sum
+	output logic V // overflow flag
+);
+	localparam MAX = 2**(width-1) -1;
+	localparam MIN = - 2**(width-1);
+	logic signed [width+1:0] Sext, Aext, Bext, CIext;
+	assign Aext = signed'(A);
+	assign Bext = signed'(B);
+	assign CIext = {{width-1{1'b0}},CI};
+
+	assign Sext = (Aext - Bext -CIext);
+	assign S = Sext[width-1:0];
+	assign V = (Sext>MAX) | (Sext<MIN);
+endmodule
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/SubVZ.sv
+++ b/src-flattened/SubVZ.sv
@@ -1,0 +1,265 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Binary subtractor using parallel-prefix carry-lookahead logic with:
+//   - carry-in (CI), subtracted
+//   - 2's complement overflow flag (V)
+//   - zero flag (only valid for CI = 0)
+// S = A -B -CI
+// V = (S>MAX) | (S<MIN)
+// Z = (S==0)
+
+module SubVZ #(
+	parameter width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [width-1:0] A,  // operands
+	input logic [width-1:0] B,
+	input logic CI,  // carry in (subtracted)
+	output logic [width-1:0] S,  // sum
+	output logic V, // overflow flag
+	output logic Z  // zero flag (only valid for CI = 0)
+);
+
+	logic [width-1:0] BI;  // B inverted
+	logic CII;  // CI inverted
+	logic [width-1:0] GI, PI;  // prefix gen./prop. in
+	logic [width-1:0] GO, PO;  // prefix gen./prop. out
+	logic [width-1:0] PT;  // adder propagate temp
+
+	// invert B and CI for subtraction
+	assign BI = ~B;
+	assign CII = ~CI;
+
+	// calculate prefix input generate/propagate signal (0)
+	assign GI[0] = (A[0] & BI[0]) | (A[0] & CII) | (BI[0] & CII);
+	assign PI[0] = A[0] ^ BI[0];
+	// calculate adder propagate signal (0) (PT = A xor B)
+	assign PT[0] = PI[0];
+	// calculate prefix input generate/propagate signals (1 to width-1)
+	generate
+		for (genvar i = 1; i < width; i++) begin : preproc
+			assign GI[i] = A[i] & BI[i];
+			assign PI[i] = A[i] ^ BI[i];
+			// calculate adder propagate signal (1 to width-1) (PT = A xor B)
+			assign PT[i] = PI[i];
+		end
+	endgenerate
+
+	// calculate prefix output generate/propagate signals
+	PrefixAndOr #(
+		.width(width),
+		.speed(speed)
+	) prefix_inst (
+		.GI(GI),
+		.PI(PI),
+		.GO(GO),
+		.PO(PO)
+	);
+
+	// calculate sum and overflow bits
+	assign S = PT ^ {GO[width-2:0], CII};
+	assign V = GO[width-1] ^ GO[width-2];
+	assign Z = PO[width-1];
+
+endmodule
+
+
+
+module behavioural_SubVZ #(
+	parameter width = 8,  // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input logic [width-1:0] A,  // operands
+	input logic [width-1:0] B,
+	input logic CI,  // carry in (subtracted)
+	output logic [width-1:0] S,  // sum
+	output logic V, // overflow flag
+	output logic Z  // zero flag (only valid for CI = 0)
+);
+	localparam MAX = 2**(width-1) -1;
+	localparam MIN = - 2**(width-1);
+	logic signed [width+1:0] Sext, Aext, Bext, CIext;
+	assign Aext = signed'(A);
+	assign Bext = signed'(B);
+	assign CIext = {{width-1{1'b0}},CI};
+
+	assign Sext = (Aext - Bext -CIext);
+	assign S = Sext[width-1:0];
+	assign V = (Sext>MAX) | (Sext<MIN);
+	assign Z = CI ? 'x : (Sext == '0);
+endmodule
+
+
+module PrefixAndOr #(
+	parameter int              width = 8,             // word width
+	parameter lau_pkg::speed_e speed = lau_pkg::FAST  // performance parameter
+) (
+	input  logic [width-1:0] GI,  // gen./prop. in
+	input  logic [width-1:0] PI,  // gen./prop. in
+	output logic [width-1:0] GO,  // gen./prop. out
+	output logic [width-1:0] PO   // gen./prop. out
+);
+
+	// Constants
+	localparam int n = width;  // prefix structure width
+	localparam int m = $clog2(width);  // prefix structure depth
+
+	// Sklansky parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::FAST) begin : fastPrefix
+		logic [(m+1)*n-1:0] GT, PT;  // gen./prop. temp
+			assign GT[n-1:0] = GI;
+			assign PT[n-1:0] = PI;
+			for (genvar l = 1; l <= m; l++) begin : levels
+				for (genvar k = 0; k < 2 ** (m - l); k++) begin : groups
+					for (genvar i = 0; i < 2 ** (l - 1); i++) begin : bits
+						// pass prop and gen to following nodes
+						if ((k * 2 ** l + i) < n) begin : white
+							assign GT[l*n+k*2**l+i] = GT[(l-1)*n+k*2**l+i];
+							assign PT[l*n+k*2**l+i] = PT[(l-1)*n+k*2**l+i];
+						end
+						// calculate new propagate and generate
+						if ((k * 2 ** l + 2 ** (l - 1) + i) < n) begin : black
+							assign GT[l*n + k*2**l + 2**(l-1) + i] = 
+												GT[(l-1)*n + k*2**l + 2**(l-1) + i]
+											  | (  PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												 & GT[(l-1)*n + k*2**l + 2**(l-1) - 1] );
+							assign PT[l*n + k*2**l + 2**(l-1) + i] = 
+													PT[(l-1)*n + k*2**l + 2**(l-1) + i]
+												  & PT[(l-1)*n + k*2**l + 2**(l-1) - 1];
+						end
+					end
+				end
+			end
+			assign GO = GT[(m+1)*n-1 : m*n];
+			assign PO = PT[(m+1)*n-1 : m*n];
+	end
+
+	// Brent-Kung parallel-prefix carry-lookahead structure
+	if (speed == lau_pkg::MEDIUM) begin : mediumPrefix
+		logic [(2*m)*n -1:0] GT, PT;  // gen./prop. temp
+		assign GT[n-1:0] = GI;
+		assign PT[n-1:0] = PI;
+
+		for (genvar l = 1; l <= m; l++) begin : levels1
+			for (genvar k = 0; k < 2**(m-l); k++) begin : groups
+				for (genvar i = 0; i < 2**l -1; i++) begin : bits
+					if ((k* 2**l +i) < n) begin : white
+						assign GT[l*n + k* 2**l +i] = GT[(l-1)*n + k* 2**l +i];
+						assign PT[l*n + k* 2**l +i] = PT[(l-1)*n + k* 2**l +i];
+					end // white
+				end // bits
+				if ((k* 2**l + 2**l -1) < n) begin : black
+					assign GT[l*n + k* 2**l + 2**l -1] =
+								GT[(l-1)*n + k* 2**l + 2**l - 1] |
+							  | (  PT[(l-1)*n + k* 2**l + 2**l     -1] 
+							     & GT[(l-1)*n + k* 2**l + 2**(l-1) -1]);
+					assign PT[l*n + k* 2**l + 2**l -1] =
+								PT[(l-1)*n + k*2**l + 2**l     -1] 
+							  & PT[(l-1)*n + k*2**l + 2**(l-1) -1];
+				end // black
+			end
+		end // level1
+		for (genvar l = m +1; l < 2*m; l++) begin : levels2
+			for (genvar i = 0; i < 2**(2*m -l); i++) begin : bits
+				if (i < n) begin : white
+					assign GT[l*n +i] = GT[(l-1)*n +i];
+					assign PT[l*n +i] = PT[(l-1)*n +i];
+				end // white
+			end // bits
+			for (genvar k = 1; k < 2**(l-m); k++) begin : groups
+				if (l < 2*m -1) begin : empty
+					for (genvar i = 0; i < 2**(2*m -l -1) -1; i++) begin : bits
+						if ((k* 2**(2*m -l) +i) < n) begin : white
+							assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+							assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+						end // white
+					end
+				end // empty
+				if ((k* 2**(2*m -l) + 2**(2*m -l -1) -1) < n) begin : black
+					assign GT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								GT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m -l-1) -1]
+							  | (  PT[(l-1)*n + k* 2**(2*m-l) + 2**(2*m-l-1) -1] 
+								 & GT[(l-1)*n + k* 2**(2*m-l) -1] );
+					assign PT[l*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1] = 
+								PT[(l-1)*n + k* 2**(2*m -l) + 2**(2*m -l-1) -1]
+							  & PT[(l-1)*n + k* 2**(2*m -l) -1];
+				end // black
+				for (genvar i = 2**(2*m -l-1); i < 2**(2*m -l); i++) begin : bits
+					if ((k* 2**(2*m -l) +i) < n) begin : white
+						assign GT[l*n + k* 2**(2*m -l) +i] = GT[(l-1)*n + k* 2**(2*m -l) +i];
+						assign PT[l*n + k* 2**(2*m -l) +i] = PT[(l-1)*n + k* 2**(2*m -l) +i];
+					end // white
+				end
+			end
+		end // level2
+		assign GO = GT[2*m*n -1 : (2*m -1) * n];
+		assign PO = PT[2*m*n -1 : (2*m -1) * n];
+	end  // Serial-prefix carry-lookahead structure
+	else if (speed == lau_pkg::SLOW) begin : slowPrefix
+		logic [n-1:0] GT, PT;  // gen./prop. temp
+		assign GT[0] = GI[0];
+		assign PT[0] = PI[0];
+		
+		for (genvar i = 1; i < n; i++) begin : bits
+			assign GT[i] = GI[i] | (PI[i] & GT[i-1]);
+			assign PT[i] = PI[i] & PT[i-1];
+		end
+		assign GO = GT;
+		assign PO = PT;
+	end
+
+endmodule

--- a/src-flattened/SumZeroDet.sv
+++ b/src-flattened/SumZeroDet.sv
@@ -1,0 +1,121 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Description :
+// Detects an all-zeroes sum of an addition in constant time, i.e. without
+// waiting for the slow addition result (or without performing the addition).
+// Z = ( (A + B +CI)==0 )
+
+module SumZeroDet #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,
+	input  logic [width-1:0] B,  // operands
+	input  logic             CI,  // carry in
+	output logic             Z    // all-zeroes sum flag
+);
+
+	// zero flag for individual bits
+	logic [width-1:0] ZT;
+	always_comb begin
+		ZT[0] = ~((A[0] ^ B[0]) ^ CI);
+		for (int i = 1; i < width; i++) begin
+			ZT[i] = ~((A[i] ^ B[i]) ^ (A[i-1] | B[i-1]));
+		end
+	end
+
+	// AND all bit zero flags
+	RedAnd #(
+		.width(width)
+	) zeroFlag (
+		.A(ZT),
+		.Z(Z)
+	);
+
+endmodule
+
+
+
+module behavioural_SumZeroDet #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,
+	input  logic [width-1:0] B,  // operands
+	input  logic             CI,  // carry in
+	output logic             Z    // all-zeroes sum flag
+);
+	assign Z = ((A+B+CI) == '0);
+endmodule
+
+module RedAnd #(
+	parameter int width = 8  // word width
+) (
+	input  logic [width-1:0] A,  // input vector
+	output logic             Z   // output bit
+);
+
+	logic zv;
+
+	// AND all bits
+	// Using a procedural block for behavioral description
+	always_comb begin
+		zv = A[0];
+		for (int i = 1; i < width; i++) begin
+			zv &= A[i];
+		end
+		Z = zv;
+	end
+
+endmodule

--- a/src-flattened/arith_utils.sv
+++ b/src-flattened/arith_utils.sv
@@ -1,0 +1,82 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage
+
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Based on the work by Reto Zimmermann 1998 - ETH Zürich
+// Originally written in VHDL, available under: 
+// https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library
+//
+// Authors:
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+// - Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+package lau_pkg;
+
+
+	// Computes floor(log2(n))
+	// Input n should be greater than 0 for meaningful results
+	function automatic integer log2floor;
+		input integer n;
+		integer m;
+		integer p;
+		begin
+			m = -1;
+			p = 1;
+			while (p <= n) begin
+				m = m + 1;
+				p = p * 2;
+			end
+			log2floor = m;
+		end
+	endfunction
+
+	typedef enum logic [1:0] {
+		SLOW = 2'b00,
+		MEDIUM = 2'b01,
+		FAST = 2'b10
+	} speed_e;
+
+endpackage


### PR DESCRIPTION
## Summary
- add flatten_sv.py script that copies all modules into per-file flattened versions
- generate flattened modules in `src-flattened/`

## Testing
- `python3 flatten_sv.py`
